### PR TITLE
Fix default section styling

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -54,8 +54,11 @@
     --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
     --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
     --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
+
+    background-color: #2b2b2b;
+    color: white;
   }
-  
+
   /* fonts */
   --calcite-code-family: "Consolas", "Andale Mono", "Lucida Console", "Monaco", monospace;
   --calcite-sans-family: "Avenir Next", "Avenir", "Helvetica Neue", sans-serif;
@@ -306,6 +309,10 @@ main {
   }
 
   /* sections */
+
+  .section > .default-content-wrapper {
+    text-align: center;
+  }
 
   .section > div > div {
     background-color: var(--calcite-ui-foreground-1);

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -54,9 +54,6 @@
     --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
     --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
     --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
-
-    background-color: #2b2b2b;
-    color: white;
   }
 
   /* fonts */
@@ -116,6 +113,9 @@ body.appear {
 }
 
 main {
+  background-color: var(--calcite-ui-foreground-1);
+  color: var(--calcite-ui-text-1);
+
   *,
   *::before,
   *::after {
@@ -311,7 +311,7 @@ main {
   /* sections */
 
   .section > .default-content-wrapper {
-    text-align: center;
+    /* text-align: center; */
   }
 
   .section > div > div {


### PR DESCRIPTION
Partial fix for #253 

It fixes the color and background in sections with calcite-mode-dark and also centers the content in default-content-wrapper

Before:
![image](https://github.com/user-attachments/assets/47335075-58c7-41a2-bcf8-8f1fa07a5536)

After:
![image](https://github.com/user-attachments/assets/ec946bf7-08b7-434c-b755-75abe51fbd74)


Test URLs:
- Original: https://www.esri.com/fr-fr/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/fr-fr/about/about-esri/overview
- After: https://fix-themebackground--esri-eds--esri.aem.live/fr-fr/about/about-esri/overview
