### PR TITLE
fix: revert to Abode sharepoint

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://esriis.sharepoint.com/sites/EsriMarketingPublic/Shared%20Documents/Forms/AllItems.aspx?csf=1&web=1&e=xhHL73&CID=4f0d4a19%2Dc191%2D4017%2D93fc%2D15e1f8c7ced9&FolderCTID=0x0120004B62D30BCEE04048920D4FF8BA2FC52A&id=%2Fsites%2FEsriMarketingPublic%2FShared%20Documents%2Fsites%2Fesri&viewid=646d13d0%2Dbc57%2D41ae%2D855a%2D804a11f5ac5c
+  /: https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FHelixProjects%2FShared%20Documents%2Fsites%2Fesri&viewid=124ad5f1%2D60ba%2D476c%2Dade8%2D7c1df274ee95


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://sharepoint-revert--esri-eds--esri.aem.live/
