### PR TITLE
Convert link buttons to calcite buttons for Storyteller

### DIFF
--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -67,16 +67,6 @@
   font-size: var(--font-2);
 }
 
-.storyteller p.button-container a.button {
-  text-wrap: wrap;
-  line-height: 1.4;
-  text-align: start;
-  text-decoration: none;
-  padding: var(--space-3) var(--space-4);
-  font-size: var(--font-1); 
-  margin-block-start: var(--space-2);
-}
-
 .storyteller div div:nth-of-type(2) p:nth-of-type(1) picture img {
   max-inline-size: 100%;
   block-size: 100%;

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -112,13 +112,13 @@ function decorateLinkBtn(block) {
   anchorElements.forEach((anchorElement) => {
     if (!anchorElement.classList.contains('hidden')) {
       const calciteButton = document.createElement('calcite-button');
-      calciteButton.innerHTML = anchorElement.innerHTML; 
+      calciteButton.innerHTML = anchorElement.innerHTML;
       if (anchorElement.getAttribute('href')) {
-          calciteButton.setAttribute('href', anchorElement.getAttribute('href'));
+        calciteButton.setAttribute('href', anchorElement.getAttribute('href'));
       }
       if (!calciteButton.getAttribute('scale')) {
-          calciteButton.setAttribute('scale', 'l');
-      } 
+        calciteButton.setAttribute('scale', 'l');
+      }
       anchorElement.replaceWith(calciteButton);
     }
   });

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -10,6 +10,7 @@ function isMP4(vidUrls) {
   vidUrls.forEach((url) => {
     if (mp4Regex.test(url)) {
       url.parentNode.classList.add('foreground-container');
+      url.classList.add('hidden');
       mp4Video = true;
     }
   });
@@ -102,6 +103,27 @@ function getMP4(block) {
   return mp4Urls;
 }
 
+/**
+ * convert link button to calcite button
+ * @param {element} block The block element
+ */
+function decorateLinkBtn(block) {
+  const anchorElements = block.querySelectorAll('a');
+  anchorElements.forEach((anchorElement) => {
+    if (!anchorElement.classList.contains('hidden')) {
+      const calciteButton = document.createElement('calcite-button');
+      calciteButton.innerHTML = anchorElement.innerHTML; 
+      if (anchorElement.getAttribute('href')) {
+          calciteButton.setAttribute('href', anchorElement.getAttribute('href'));
+      }
+      if (!calciteButton.getAttribute('scale')) {
+          calciteButton.setAttribute('scale', 'l');
+      } 
+      anchorElement.replaceWith(calciteButton);
+    }
+  });
+}
+
 export default async function decorate(block) {
   const pTags = block.querySelectorAll('p');
   const pictureTagLeft = pTags[0].querySelector('picture');
@@ -161,4 +183,6 @@ export default async function decorate(block) {
   videoBtn.addEventListener('click', () => {
     toggleVideo(videoBtn);
   });
+
+  decorateLinkBtn(block);
 }


### PR DESCRIPTION
Convert all button links into calcite buttons

Fix #278 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://storyteller-calcite-cta--esri-eds--esri.aem.live/

1. Confirm buttons are calcite-button element in web inspector. <calcite-button>