### PR TITLE
fix: flip opacity colors for light/dark

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -29,6 +29,7 @@
   --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
   --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
   --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
+  
   /* image filters */
   --image-white-filter: brightness(0) saturate(100%) invert(100%) sepia(9%) saturate(1857%) hue-rotate(0deg) brightness(109%) contrast(108%);
 

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -29,7 +29,7 @@
   --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
   --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
   --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
-  
+
   /* image filters */
   --image-white-filter: brightness(0) saturate(100%) invert(100%) sepia(9%) saturate(1857%) hue-rotate(0deg) brightness(109%) contrast(108%);
 
@@ -39,7 +39,7 @@
     --esri-ui-opacity00: rgb(53 53 53 / 0%);
     --esri-ui-opacity20: rgb(53 53 53 / 20%);
     --esri-ui-opacity40: rgb(53 53 53 / 40%);
-    --esri-ui-opacity60: rgb(53 53 53 / 50%);
+    --esri-ui-opacity50: rgb(53 53 53 / 50%);
     --esri-ui-opacity80: rgb(53 53 53 / 80%);
     --esri-ui-opacity85: rgb(53 53 53 / 85%);
     --esri-ui-opacity90: rgb(53 53 53 / 90%);

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -11,49 +11,48 @@
  */
 :root {
   /* esri.com colors with opacity */
-  --esri-ui-opacity00: rgb(53 53 53 / 0%);
-  --esri-ui-opacity20: rgb(53 53 53 / 20%);
-  --esri-ui-opacity40: rgb(53 53 53 / 40%);
-  --esri-ui-opacity60: rgb(53 53 53 / 50%);
-  --esri-ui-opacity80: rgb(53 53 53 / 80%);
-  --esri-ui-opacity85: rgb(53 53 53 / 85%);
-  --esri-ui-opacity90: rgb(53 53 53 / 90%);
-  --esri-ui-opacity95: rgb(53 53 53 / 95%);
-  --esri-ui-opacity97: rgb(53 53 53 / 97%);
-  --esri-ui-opacity00-inverse: rgb(255 255 255/ 0%);
-  --esri-ui-opacity20-inverse: rgb(255 255 255/ 2%);
-  --esri-ui-opacity40-inverse: rgb(255 255 255/ 4%);
-  --esri-ui-opacity50-inverse: rgb(255 255 255/ 5%);
-  --esri-ui-opacity80-inverse: rgb(255 255 255/ 80%);
-  --esri-ui-opacity85-inverse: rgb(255 255 255/ 85%);
-  --esri-ui-opacity90-inverse: rgb(255 255 255/ 90%);
-  --esri-ui-opacity95-inverse: rgb(255 255 255/ 95%);
-  --esri-ui-opacity97-inverse: rgb(255 255 255/ 97%);
-
+  --esri-ui-opacity00: rgb(255 255 255/ 0%);
+  --esri-ui-opacity20: rgb(255 255 255/ 20%);
+  --esri-ui-opacity40: rgb(255 255 255/ 40%);
+  --esri-ui-opacity50: rgb(255 255 255/ 50%);
+  --esri-ui-opacity80: rgb(255 255 255/ 80%);
+  --esri-ui-opacity85: rgb(255 255 255/ 85%);
+  --esri-ui-opacity90: rgb(255 255 255/ 90%);
+  --esri-ui-opacity95: rgb(255 255 255/ 95%);
+  --esri-ui-opacity97: rgb(255 255 255/ 97%);
+  --esri-ui-opacity00-inverse: rgb(53 53 53 / 0%);
+  --esri-ui-opacity20-inverse: rgb(53 53 53 / 2%);
+  --esri-ui-opacity40-inverse: rgb(53 53 53 / 4%);
+  --esri-ui-opacity50-inverse: rgb(53 53 53 / 5%);
+  --esri-ui-opacity80-inverse: rgb(53 53 53 / 80%);
+  --esri-ui-opacity85-inverse: rgb(53 53 53 / 85%);
+  --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
+  --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
+  --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
   /* image filters */
   --image-white-filter: brightness(0) saturate(100%) invert(100%) sepia(9%) saturate(1857%) hue-rotate(0deg) brightness(109%) contrast(108%);
 
   -webkit-font-smoothing: antialiased;
 
   .calcite-mode-dark {
-    --esri-ui-opacity00: rgb(255 255 255/ 0%);
-    --esri-ui-opacity20: rgb(255 255 255/ 20%);
-    --esri-ui-opacity40: rgb(255 255 255/ 40%);
-    --esri-ui-opacity50: rgb(255 255 255/ 50%);
-    --esri-ui-opacity80: rgb(255 255 255/ 80%);
-    --esri-ui-opacity85: rgb(255 255 255/ 85%);
-    --esri-ui-opacity90: rgb(255 255 255/ 90%);
-    --esri-ui-opacity95: rgb(255 255 255/ 95%);
-    --esri-ui-opacity97: rgb(255 255 255/ 97%);
-    --esri-ui-opacity00-inverse: rgb(53 53 53 / 0%);
-    --esri-ui-opacity20-inverse: rgb(53 53 53 / 2%);
-    --esri-ui-opacity40-inverse: rgb(53 53 53 / 4%);
-    --esri-ui-opacity50-inverse: rgb(53 53 53 / 5%);
-    --esri-ui-opacity80-inverse: rgb(53 53 53 / 80%);
-    --esri-ui-opacity85-inverse: rgb(53 53 53 / 85%);
-    --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
-    --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
-    --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
+    --esri-ui-opacity00: rgb(53 53 53 / 0%);
+    --esri-ui-opacity20: rgb(53 53 53 / 20%);
+    --esri-ui-opacity40: rgb(53 53 53 / 40%);
+    --esri-ui-opacity60: rgb(53 53 53 / 50%);
+    --esri-ui-opacity80: rgb(53 53 53 / 80%);
+    --esri-ui-opacity85: rgb(53 53 53 / 85%);
+    --esri-ui-opacity90: rgb(53 53 53 / 90%);
+    --esri-ui-opacity95: rgb(53 53 53 / 95%);
+    --esri-ui-opacity97: rgb(53 53 53 / 97%);
+    --esri-ui-opacity00-inverse: rgb(255 255 255/ 0%);
+    --esri-ui-opacity20-inverse: rgb(255 255 255/ 2%);
+    --esri-ui-opacity40-inverse: rgb(255 255 255/ 4%);
+    --esri-ui-opacity50-inverse: rgb(255 255 255/ 5%);
+    --esri-ui-opacity80-inverse: rgb(255 255 255/ 80%);
+    --esri-ui-opacity85-inverse: rgb(255 255 255/ 85%);
+    --esri-ui-opacity90-inverse: rgb(255 255 255/ 90%);
+    --esri-ui-opacity95-inverse: rgb(255 255 255/ 95%);
+    --esri-ui-opacity97-inverse: rgb(255 255 255/ 97%);
   }
 
   /* fonts */


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #267 
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://mghover--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
