### PR TITLE
Fix: Icon path

### DIFF
--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -459,11 +459,14 @@ function decorateIcon(span, prefix = '', alt = '') {
     .substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
-  img.src = `${window.hlx.codeBasePath}icons/${iconName}.svg`;
+  //img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
+  img.src = `${prefix}/icons/${iconName}.svg`;
   img.alt = alt;
   img.loading = 'lazy';
   span.append(img);
 }
+
+
 
 /**
  * Add <img> for icons, prefixed with codeBasePath and optional prefix.

--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -459,14 +459,12 @@ function decorateIcon(span, prefix = '', alt = '') {
     .substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
-  //img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
+  //  img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
   img.src = `${prefix}/icons/${iconName}.svg`;
   img.alt = alt;
   img.loading = 'lazy';
   span.append(img);
 }
-
-
 
 /**
  * Add <img> for icons, prefixed with codeBasePath and optional prefix.

--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -459,7 +459,7 @@ function decorateIcon(span, prefix = '', alt = '') {
     .substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
-  img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
+  img.src = `${window.hlx.codeBasePath}icons/${iconName}.svg`;
   img.alt = alt;
   img.loading = 'lazy';
   span.append(img);


### PR DESCRIPTION
@alexcarol  `${window.hlx.codeBasePath}` was returning the string `eds` resulting in 404 for icons. See Jane Goodall tab. I added an icon in my draft version.

returns ==> /eds/icons/customer-satisfaction-48.svg
correct path ==> /icons/customer-satisfaction-48.svg

Fix #<gh-issue-id>

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://iconpath--esri-eds--esri.aem.page/drafts/timw/overview
