### PR TITLE
feat: in no img, assume video link is foreground

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -47,7 +47,7 @@ main .hero-container {
   align-items: flex-end;
 }
 
-.hero .hero-fg-image .foreground-img {
+.hero .hero-fg-image :is(.foreground-img, video) {
   inline-size: 700px;
   block-size: 700px;
   margin: 0;
@@ -138,6 +138,10 @@ main .hero-container {
     block-size: 100%;
     object-fit: cover;
     z-index: -1;
+  }
+
+  .hero .hero-fg-image video {
+    position: initial;
   }
   
   .hero > div > div {

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -25,7 +25,7 @@ export default function decorate(block) {
   videoSrc.setAttribute('type', 'video/mp4');
 
   if (videoElement) videoElement.append(videoSrc);
-  if (videoAssets) block.prepend(videoElement);
+  // if (videoAssets) block.prepend(videoElement);
 
   const contentDiv = block.querySelector('div:last-child');
   const contentChildDiv = contentDiv.querySelector('div');
@@ -34,6 +34,12 @@ export default function decorate(block) {
   const heroContent = domEl('div', { class: 'hero-content' });
   const heroContentWrapper = domEl('div', { class: 'hero-content-wrapper' });
   const heroFgImage = domEl('div', { class: 'hero-fg-image' });
+
+  // If there is no image, assume video is the foreground image
+  if (heroFgImage.children.length === 0) {
+    heroFgImage.appendChild(videoElement)
+  }
+  
   heroContent.prepend(heroContentWrapper);
   block.prepend(heroContent, heroFgImage);
 

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -37,9 +37,9 @@ export default function decorate(block) {
 
   // If there is no image, assume video is the foreground image
   if (heroFgImage.children.length === 0) {
-    heroFgImage.appendChild(videoElement)
+    heroFgImage.appendChild(videoElement);
   }
-  
+
   heroContent.prepend(heroContentWrapper);
   block.prepend(heroContent, heroFgImage);
 


### PR DESCRIPTION
Still missing background image. For now assuming if no image, video link is foreground image

Fix #271

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview
- After: https://banner--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview
