### PR TITLE
Storyteller Missing Icons on Location Page

### DIFF
--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -149,6 +149,43 @@
   margin-inline-end: var(--space-4); 
 }
 
+.storyteller div:nth-of-type(1) div:nth-of-type(1) div.icon-wrapper {
+  padding-inline-start: 0;
+}
+
+.storyteller div:nth-of-type(1) div:nth-of-type(1) .icon-wrapper .storyteller-row {
+  display: flex;
+  inline-size: 100%;
+  flex-direction: row;
+  padding-inline: 0;
+}
+
+.storyteller div:nth-of-type(1) div:nth-of-type(1) .icon-wrapper .storyteller-row .storyteller-content {
+  inline-size: 100%;
+  padding-inline: 0;
+}
+
+.storyteller .icon-wrapper .storyteller-row .storyteller-content .icon-paragraph {
+  padding-inline: 0;
+}
+
+.storyteller .icon-wrapper .storyteller-row picture.icon-picture {
+  padding-inline-end: var(--space-8);
+}
+
+.storyteller .icon-wrapper .storyteller-row picture.icon-picture img {
+  max-inline-size: max-content;
+  block-size: auto;
+}
+
+.storyteller div:nth-of-type(1) div:nth-of-type(1) .icon-wrapper .storyteller-row .icon-title {
+  padding-inline: 0;
+}
+
+.storyteller div div p.hidden {
+  display: none;
+}
+
 @media (width >= 510px) {
   .storyteller button.video-playbutton {
     margin-inline-end: var(--space-4); 
@@ -177,6 +214,12 @@
     position: relative;
     min-block-size: 1100px;
   }
+
+  .storyteller div:nth-of-type(1) div:nth-of-type(1) div.icon-wrapper {
+  inline-size: 100%;
+  padding-inline-start: var(--space-32);
+  margin-block-start: var(--space-4);
+}
 
   .section > div.storyteller-wrapper, .storyteller .foreground-content .content-wrapper h2 {
     margin-block-end: 0;

--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -219,6 +219,8 @@
   inline-size: 100%;
   padding-inline-start: var(--space-32);
   margin-block-start: var(--space-4);
+  max-inline-size: 660px;
+  margin-inline-start: auto;
 }
 
   .section > div.storyteller-wrapper, .storyteller .foreground-content .content-wrapper h2 {

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -132,6 +132,43 @@ function decorateLinkBtn(block) {
   });
 }
 
+function decorateIcons(block) {
+  const iconWrapper = document.createElement('div');
+  iconWrapper.classList.add('icon-wrapper');
+
+  block.querySelectorAll('picture').forEach((picture, indx) => {
+    picture.classList.add('icon-picture');
+    let iconHTML = picture.closest('p').innerHTML;
+    if (indx === 0) {
+      let iconParentWrapper = picture.closest('p').parentNode;
+      iconParentWrapper.insertBefore(iconWrapper, iconParentWrapper.lastElementChild);
+    }
+    if (picture.classList.contains('hide-poster')) {
+      picture.classList.remove('hide-poster');
+    }
+    if (/<\/picture>[a-z|A-Z]+/.test(picture.closest('p').innerHTML)) {
+      let iconTitle = iconHTML.match(/<\/picture>\s*([a-z|A-Z| ]+)/);
+      let storytellerGroup = document.createElement('div');
+      let storytellerTitle = document.createElement('div');
+      let storytellerContent = document.createElement('div');
+      let imgPicture = picture.querySelector('img');
+      picture.closest('p').classList.add('hidden');
+      imgPicture.classList.add('icon-48');
+      storytellerGroup.classList.add('storyteller-row');
+      storytellerContent.classList.add('storyteller-content');
+      storytellerTitle.innerHTML = iconTitle[1];
+      let iconParagraph = picture.closest('p').nextElementSibling;
+      iconParagraph.classList.add('icon-paragraph');
+      storytellerTitle.classList.add('icon-title');
+      storytellerGroup.appendChild(picture);
+      storytellerContent.append(storytellerTitle);
+      storytellerContent.append(iconParagraph);
+      storytellerGroup.appendChild(storytellerContent);
+      iconWrapper.appendChild(storytellerGroup);
+    }
+  });
+}
+
 export default async function decorate(block) {
   const pTags = block.querySelectorAll('p');
   const pictureTagLeft = pTags[0].querySelector('picture');
@@ -206,4 +243,5 @@ export default async function decorate(block) {
   });
 
   decorateLinkBtn(block);
+  decorateIcons(block);
 }

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -152,8 +152,7 @@ function decorateIcons(block) {
       const storytellerTitle = document.createElement('div');
       const storytellerContent = document.createElement('div');
       const imgPicture = picture.querySelector('img');
-      const iconParagraph = picture.closest('p').nextElementSibling;
-    
+      const iconParagraph = picture.closest('p').nextElementSibling;    
       picture.closest('p').classList.add('hidden');
       imgPicture.classList.add('icon-48');
       storytellerGroup.classList.add('storyteller-row');
@@ -161,7 +160,6 @@ function decorateIcons(block) {
       storytellerTitle.innerHTML = iconTitle[1];
       iconParagraph.classList.add('icon-paragraph');
       storytellerTitle.classList.add('icon-title');
-    
       storytellerGroup.appendChild(picture);
       storytellerContent.append(storytellerTitle);
       storytellerContent.append(iconParagraph);

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -89,6 +89,7 @@ async function setVideoTag(foregroundSrc) {
   const videoTag = document.createElement('video');
   videoTag.muted = true;
   videoTag.toggleAttribute('autoplay', 'true');
+  videoTag.toggleAttribute('loop', true);
   videoTag.toggleAttribute('playsinline', true);
   videoTag.setAttribute('type', 'video/mp4');
   videoTag.setAttribute('poster', foregroundSrc);

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -152,7 +152,7 @@ function decorateIcons(block) {
       const storytellerTitle = document.createElement('div');
       const storytellerContent = document.createElement('div');
       const imgPicture = picture.querySelector('img');
-      const iconParagraph = picture.closest('p').nextElementSibling;    
+      const iconParagraph = picture.closest('p').nextElementSibling;
       picture.closest('p').classList.add('hidden');
       imgPicture.classList.add('icon-48');
       storytellerGroup.classList.add('storyteller-row');

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -138,28 +138,30 @@ function decorateIcons(block) {
 
   block.querySelectorAll('picture').forEach((picture, indx) => {
     picture.classList.add('icon-picture');
-    let iconHTML = picture.closest('p').innerHTML;
+    const iconHTML = picture.closest('p').innerHTML;
     if (indx === 0) {
-      let iconParentWrapper = picture.closest('p').parentNode;
+      const iconParentWrapper = picture.closest('p').parentNode;
       iconParentWrapper.insertBefore(iconWrapper, iconParentWrapper.lastElementChild);
     }
     if (picture.classList.contains('hide-poster')) {
       picture.classList.remove('hide-poster');
     }
     if (/<\/picture>[a-z|A-Z]+/.test(picture.closest('p').innerHTML)) {
-      let iconTitle = iconHTML.match(/<\/picture>\s*([a-z|A-Z| ]+)/);
-      let storytellerGroup = document.createElement('div');
-      let storytellerTitle = document.createElement('div');
-      let storytellerContent = document.createElement('div');
-      let imgPicture = picture.querySelector('img');
+      const iconTitle = iconHTML.match(/<\/picture>\s*([a-z|A-Z| ]+)/);
+      const storytellerGroup = document.createElement('div');
+      const storytellerTitle = document.createElement('div');
+      const storytellerContent = document.createElement('div');
+      const imgPicture = picture.querySelector('img');
+      const iconParagraph = picture.closest('p').nextElementSibling;
+    
       picture.closest('p').classList.add('hidden');
       imgPicture.classList.add('icon-48');
       storytellerGroup.classList.add('storyteller-row');
       storytellerContent.classList.add('storyteller-content');
       storytellerTitle.innerHTML = iconTitle[1];
-      let iconParagraph = picture.closest('p').nextElementSibling;
       iconParagraph.classList.add('icon-paragraph');
       storytellerTitle.classList.add('icon-title');
+    
       storytellerGroup.appendChild(picture);
       storytellerContent.append(storytellerTitle);
       storytellerContent.append(iconParagraph);

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -214,11 +214,7 @@ export default async function decorate(block) {
       const foregroundWrapper = block.querySelector('.foreground-container');
       foregroundContentContainer.classList.add('foreground-content');
       foregroundContent.appendChild(h2Tags[1]);
-      if (pTags.length > 5) {
-        foregroundContent.appendChild(pTags[pTags.length - 1]);
-      } else {
-        foregroundContent.appendChild(pTags[4]);
-      }
+      foregroundContent.appendChild(pTags[pTags.length - 1]);
       foregroundContentContainer.appendChild(foregroundContent);
       foregroundWrapper.appendChild(foregroundContentContainer);
     }

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -89,7 +89,6 @@ async function setVideoTag(foregroundSrc) {
   const videoTag = document.createElement('video');
   videoTag.muted = true;
   videoTag.toggleAttribute('autoplay', 'true');
-  videoTag.toggleAttribute('loop', true);
   videoTag.toggleAttribute('playsinline', true);
   videoTag.setAttribute('type', 'video/mp4');
   videoTag.setAttribute('poster', foregroundSrc);

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -153,11 +153,12 @@ function decorateIcons(block) {
       const storytellerContent = document.createElement('div');
       const imgPicture = picture.querySelector('img');
       const iconParagraph = picture.closest('p').nextElementSibling;
+      const [, secondTitle] = iconTitle;
       picture.closest('p').classList.add('hidden');
       imgPicture.classList.add('icon-48');
       storytellerGroup.classList.add('storyteller-row');
       storytellerContent.classList.add('storyteller-content');
-      storytellerTitle.innerHTML = iconTitle[1];
+      storytellerTitle.innerHTML = secondTitle;
       iconParagraph.classList.add('icon-paragraph');
       storytellerTitle.classList.add('icon-title');
       storytellerGroup.appendChild(picture);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #273 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/location
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/technology
- After: https://storytellerIcon--esri-eds--esri.aem.live/

![icons-location](https://github.com/user-attachments/assets/b073880d-b5e8-40bf-a682-aaab70b340d9)
