### PR TITLE
Storyteller autoplay video once 

### DIFF
--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -89,7 +89,6 @@ async function setVideoTag(foregroundSrc) {
   const videoTag = document.createElement('video');
   videoTag.muted = true;
   videoTag.toggleAttribute('autoplay', 'true');
-  videoTag.toggleAttribute('loop', true);
   videoTag.toggleAttribute('playsinline', true);
   videoTag.setAttribute('type', 'video/mp4');
   videoTag.setAttribute('poster', foregroundSrc);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #254

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://storytellerAutoPlay--esri-eds--esri.aem.live/
