### PR TITLE
feat: set max width on content wrapper

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -315,6 +315,11 @@ main {
 
   /* sections */
 
+  .default-content-wrapper {
+    max-inline-size: 1440px;
+    padding-inline: var(--space-6);
+  }
+
   .section:where(.center, .centered) > .default-content-wrapper {
     text-align: center;
   }
@@ -386,6 +391,12 @@ main {
       .video-iframe-wrapper {
         inline-size: 65%;
       }
+    }
+  }
+
+  @media (width >= 1488px) {
+    .default-content-wrapper {
+      padding-inline: 0;
     }
   }
 


### PR DESCRIPTION
For 'unblocked' content such as the ["Who uses AI and Location Intelligence" section](https://contentwrap--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview#:~:text=Who%20uses%20AI%20and%20location%20intelligence%3F)

Fix #316

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview
- After: https://contentwrap--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview
