### PR TITLE
fix: only active tab selected

### DIFF
--- a/eds/blocks/tabs/tabs.js
+++ b/eds/blocks/tabs/tabs.js
@@ -203,10 +203,8 @@ export default async function decorate(block) {
       e.preventDefault();
 
       const tabTitle = titles[index];
-      if (tabTitle.hasAttribute('aria-selected')) {
-        tabTitle.setAttribute('aria-selected', 'false');
-        tabTitle.setAttribute('aria-selected', 'true');
-      }
+      titles.forEach((t) => t.setAttribute('aria-selected', 'false'));
+      tabTitle.setAttribute('aria-selected', 'true');
 
       contents[selectedIdx].setAttribute('aria-hidden', 'true');
       contents[index].setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #320 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview#at&t
- After: https://tabselected--esri-eds--esri.aem.live/en-us/artificial-intelligence/overview#at&t
