### PR TITLE
fix(centered-content-switcher): background image size

### DIFF
--- a/eds/blocks/centered-content-switcher/centered-content-switcher.js
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.js
@@ -14,7 +14,7 @@ export default function decorate(block) {
   block.querySelectorAll('img').forEach((image) => image
     .closest('picture')
     .replaceWith(
-      createOptimizedPicture(image.src, image.alt, false, [{ width: '750' }]),
+      createOptimizedPicture(image.src, image.alt, false, [{ width: '2560' }]),
     ));
 
   let selectedIdx = 0;


### PR DESCRIPTION
Changed image size to `2560` in order to fix the background image size issue.

Fix #331

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://331-centered-content-switcher-poor-background-image-resolution--esri-eds--esri.aem.live/en-us/about/about-esri/americas
