### PR TITLE
Add support for calcite-button in centered-content-switcher and elastic-content-strip

### DIFF
--- a/eds/blocks/centered-content-switcher/centered-content-switcher.js
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.js
@@ -133,7 +133,7 @@ export default function decorate(block) {
 
     tab.setAttribute('style', `background-image: url(${imgUrl})`);
 
-    const anchor = tab.querySelector('a');
+    const anchor = tab.querySelector('calcite-button,a');
     const innerText = tab.innerText.split('\n').map((el) => el.trim().toLowerCase());
     const hasVideo = innerText.includes('video');
 

--- a/eds/blocks/elastic-content-strip/elastic-content-strip.js
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.js
@@ -7,7 +7,7 @@ import {
 
 export default function decorate(block) {
   block.querySelectorAll('.elastic-content-strip > div > div').forEach((div) => {
-    const linkHref = div.querySelector('a').href;
+    const linkHref = div.querySelector('a,calcite-button').href;
 
     const elasticContentWrapper = a({
       class: 'elastic-content-link-wrapper',


### PR DESCRIPTION
Fix #335

Test URLs:
Fixed centered-content-switcher:
Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
After: https://fix-contentswitcher--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview

Fixed elastic-content-strip:
Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
After: https://fix-contentswitcher--esri-eds--esri.aem.live/en-us/about/about-esri/americas
