### PR TITLE
fix(local-navigation): correct domain resolution for URL updates

### DIFF
--- a/eds/blocks/local-navigation/local-navigation.js
+++ b/eds/blocks/local-navigation/local-navigation.js
@@ -6,7 +6,7 @@ import { domEl } from '../../scripts/dom-helpers.js';
  */
 function updateURL(url) {
   const ISLOCAL = /localhost/gm;
-  const currDomain = ISLOCAL.test(window.location.href) ? 'http://localhost:3000' : '';
+  const currDomain = ISLOCAL.test(window.location.href) ? window.location.origin : '';
   return url.replace(/^https?:\/\/[^/]+/, currDomain);
 }
 


### PR DESCRIPTION
Changed the hard-coded value for `currDomain` so that other local development ports have proper domain resolution.

Fix #344

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://344-local-navigation-localhost--esri-eds--esri.aem.live/
