### PR TITLE
chore(vscode): add editor settings for ESLint and Stylelint integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit",
+    "source.organizeImports": "never"
+  },
+  "editor.formatOnSave": false,
+  "eslint.enable": true,
+  "eslint.validate": [
+    "javascript"
+  ],
+  "prettier.enable": false,
+  "stylelint.enable": true,
+  "stylelint.validate": [
+    "css"
+  ]
+}


### PR DESCRIPTION

Created a shared VSCode settings file for the project so that developers all have the same settings configured for their IDE.

Fix #376

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://vscode-settings--esri-eds--esri.aem.live/
