### PR TITLE
fix: localnav title color

### DIFF
--- a/eds/blocks/local-navigation/local-navigation.css
+++ b/eds/blocks/local-navigation/local-navigation.css
@@ -11,7 +11,9 @@
   align-items: center;
 }
 
-.local-navigation {
+.local-navigation.block {
+  background-color: inherit;
+  color: inherit;
   inline-size: 1440px;
   margin-inline: var(--space-8);
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #383 
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
- After: https://navcolor--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
