### PR TITLE
feat: adjust tab sizes, align to bottom

### DIFF
--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -122,7 +122,7 @@ p, h2 {
 
   .tab-nav {
     align-items: center;
-    border-block-end: 1px solid var(--calcite-ui-text-1);
+    border-block-end: 1px solid var(--calcite-ui-border-1);
     display: flex;
     inline-size: 96vw;
     justify-content: center;
@@ -131,9 +131,8 @@ p, h2 {
     position: relative;
 
     .tab-titles {
-      align-items: center;
+      align-items: flex-end;
       display: flex;
-      inline-size: 100%;
       justify-content: center;
       list-style-type: none;
       margin-block-end: 0;


### PR DESCRIPTION
Adjusting the sizes of tabs and alignment.

Fix #396

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/overview
- After: https://tabsize--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/overview
