### PR TITLE
fix: script.js remove decorateToCalcite routine.

### DIFF
--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -162,44 +162,6 @@ function decorateMode(element) {
   });
 }
 
-/**
-* convert link button to calcite button
-* @param {element} block The block element
-*/
-function decorateToCalcite(main) {
-  main.querySelectorAll('p.button-container').forEach((buttonContainer) => {
-    // create a new div to replace the buttonContainer
-    const newDiv = div({ class: 'button-container' });
-    while (buttonContainer.firstChild) {
-    // if firstchild is <a> then construct calciteButton
-      if (buttonContainer.firstChild.tagName === 'A') {
-        newDiv.appendChild(calciteButton({
-          appearance: 'solid',
-          color: 'blue',
-          kind: 'brand',
-          scale: 'm',
-          href: buttonContainer.firstChild.href,
-          alignment: 'center',
-          type: 'button',
-          width: 'auto',
-        }, buttonContainer.firstChild.textContent));
-      } else if (buttonContainer.firstChild.tagName === 'EM') {
-        newDiv.appendChild(calciteButton({
-          appearance: 'outline',
-          color: 'blue',
-          kind: 'brand',
-          scale: 'm',
-          href: buttonContainer.firstChild.firstChild.href,
-          alignment: 'center',
-          type: 'button',
-          width: 'auto',
-        }, buttonContainer.firstChild.textContent));
-      }
-      buttonContainer.removeChild(buttonContainer.firstChild);
-    }
-    buttonContainer.replaceWith(newDiv);
-  });
-}
 
 export function decorateBlockMode(block) {
   decorateMode(block);
@@ -263,7 +225,6 @@ async function loadEager(doc) {
   if (main) {
     decorateLocalNavigation(main);
     decorateMain(main);
-    decorateToCalcite(main);
     document.body.classList.add('appear');
     await waitForLCP(LCP_BLOCKS);
   }

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -17,8 +17,7 @@ import {
   div,
   iframe,
   domEl,
-  video, 
-  source,
+  video, source,
 } from './dom-helpers.js';
 
 const LCP_BLOCKS = ['header']; // add your LCP blocks to the list

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -17,7 +17,8 @@ import {
   div,
   iframe,
   domEl,
-  calciteButton, video, source,
+  video, 
+  source,
 } from './dom-helpers.js';
 
 const LCP_BLOCKS = ['header']; // add your LCP blocks to the list
@@ -161,7 +162,6 @@ function decorateMode(element) {
     }
   });
 }
-
 
 export function decorateBlockMode(block) {
   decorateMode(block);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #400

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://decorateCalciteRemove--esri-eds--esri.aem.live/
