### PR TITLE
Local Nav Set max width to 1440px

### DIFF
--- a/eds/blocks/local-navigation/local-navigation.css
+++ b/eds/blocks/local-navigation/local-navigation.css
@@ -3,6 +3,8 @@
   inset-block-start: 0;
   position: sticky;
   z-index: 3000;
+  margin: auto;
+  max-inline-size: 1440px;
 }
 
 .local-navigation-wrapper {
@@ -15,7 +17,7 @@
   background-color: inherit;
   color: inherit;
   inline-size: 1440px;
-  margin-inline: var(--space-8);
+  margin-inline: var(--space-4);
 }
 
 .local-navigation nav {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Limit width for local nav to 1440px.

Fix #405

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://localNav1440--esri-eds--esri.aem.live/

