### PR TITLE
Local Nav adjust for light mode theme

### DIFF
--- a/eds/blocks/local-navigation/local-navigation.css
+++ b/eds/blocks/local-navigation/local-navigation.css
@@ -3,8 +3,6 @@
   inset-block-start: 0;
   position: sticky;
   z-index: 3000;
-  margin: auto;
-  max-inline-size: 1440px;
 }
 
 .local-navigation-wrapper {
@@ -17,11 +15,11 @@
   background-color: inherit;
   color: inherit;
   inline-size: 1440px;
-  margin-inline: var(--space-4);
 }
 
 .local-navigation nav {
   display: flex;
+  margin-inline: var(--space-4);
 }
 
 .local-navigation .navigation-title {
@@ -96,6 +94,8 @@
   .local-navigation ul {
     margin: 0;
     justify-content: end;
+    position: relative;
+    inline-size: 1440px;
   }
 
   .local-navigation ul li a[aria-current='true'] {


### PR DESCRIPTION
Test: 
1.  full desktop > 1440px 
2. switch from calcite-dark-mode to calcite-light-mode. confirm local nav background remains dark. 

Fix #408

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://localNavLightMode--esri-eds--esri.aem.live/
