### PR TITLE
feat: change icon path

### DIFF
--- a/eds/blocks/quote/quote.js
+++ b/eds/blocks/quote/quote.js
@@ -1,4 +1,4 @@
-import { decorateIcons } from '../../scripts/aem.js';
+import { decorateIcons } from '../../scripts/scripts.js';
 import { span, ul, li } from '../../scripts/dom-helpers.js';
 
 export default function decorate(block) {

--- a/eds/blocks/quote/quote.js
+++ b/eds/blocks/quote/quote.js
@@ -18,7 +18,7 @@ export default function decorate(block) {
 
   const body = block.querySelector('.quote-block-body');
 
-  const quoteIcon = span({ class: 'icon icon-quote' });
+  const quoteIcon = span({ class: 'icon icon-quote-filled-48' });
   body.prepend(quoteIcon);
 
   decorateIcons(block);

--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -448,38 +448,6 @@ function decorateButtons(element) {
 }
 
 /**
- * Add <img> for icon, prefixed with codeBasePath and optional prefix.
- * @param {Element} [span] span element with icon classes
- * @param {string} [prefix] prefix to be added to icon src
- * @param {string} [alt] alt text to be added to icon
- */
-function decorateIcon(span, prefix = '', alt = '') {
-  const iconName = Array.from(span.classList)
-    .find((c) => c.startsWith('icon-'))
-    .substring(5);
-  const img = document.createElement('img');
-  img.dataset.iconName = iconName;
-  //  img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  // img.src = `${prefix}/icons/${iconName}.svg`;
-  img.src = `https://www.esri.com/content/dam/esrisites/en-us/common/icons/meridian-/${iconName}.svg`;
-  img.alt = alt;
-  img.loading = 'lazy';
-  span.append(img);
-}
-
-/**
- * Add <img> for icons, prefixed with codeBasePath and optional prefix.
- * @param {Element} [element] Element containing icons
- * @param {string} [prefix] prefix to be added to icon the src
- */
-function decorateIcons(element, prefix = '') {
-  const icons = [...element.querySelectorAll('span.icon')];
-  icons.forEach((span) => {
-    decorateIcon(span, prefix);
-  });
-}
-
-/**
  * Decorates all sections in a container element.
  * @param {Element} main The container element
  */
@@ -745,7 +713,6 @@ export {
   decorateBlock,
   decorateBlocks,
   decorateButtons,
-  decorateIcons,
   decorateSections,
   decorateTemplateAndTheme,
   fetchPlaceholders,

--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -460,7 +460,8 @@ function decorateIcon(span, prefix = '', alt = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   //  img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.src = `${prefix}/icons/${iconName}.svg`;
+  // img.src = `${prefix}/icons/${iconName}.svg`;
+  img.src = `https://www.esri.com/content/dam/esrisites/en-us/common/icons/meridian-/${iconName}.svg`;
   img.alt = alt;
   img.loading = 'lazy';
   span.append(img);

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -3,7 +3,6 @@ import {
   buildBlock,
   loadHeader,
   decorateButtons,
-  decorateIcons,
   decorateSections,
   decorateBlocks,
   decorateTemplateAndTheme as aemDecorateTemplateAndTheme,
@@ -190,6 +189,36 @@ function decorateModes(main) {
 }
 
 /**
+ * Add <img> for icon, prefixed with codeBasePath and optional prefix.
+ * @param {Element} [span] span element with icon classes
+ * @param {string} [prefix] prefix to be added to icon src
+ * @param {string} [alt] alt text to be added to icon
+ */
+function decorateIcon(span, prefix = '', alt = '') {
+  const iconName = Array.from(span.classList)
+    .find((c) => c.startsWith('icon-'))
+    .substring(5);
+  const img = document.createElement('img');
+  img.dataset.iconName = iconName;
+  img.src = `https://www.esri.com/content/dam/esrisites/en-us/common/icons/meridian-/${prefix}${iconName}.svg`;
+  img.alt = alt;
+  img.loading = 'lazy';
+  span.append(img);
+}
+
+/**
+ * Add <img> for icons, prefixed with codeBasePath and optional prefix.
+ * @param {Element} [element] Element containing icons
+ * @param {string} [prefix] prefix to be added to icon the src
+ */
+function decorateIcons(element, prefix = '') {
+  const icons = [...element.querySelectorAll('span.icon')];
+  icons.forEach((span) => {
+    decorateIcon(span, prefix);
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
@@ -286,3 +315,7 @@ export function decorateInnerHrefButtonsWithArrowIcon(block) {
 }
 
 loadPage();
+
+export {
+  decorateIcons,
+};


### PR DESCRIPTION
Change decorateIcon to use Esri DAM for image paths.

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/capabilities/management
- After: https://iconpath--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/capabilities/management
