### PR TITLE
Gnavlang

### DIFF
--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -118,7 +118,7 @@ async function createBreadcrumbs() {
   const urlSegments = window.location.pathname.split('/')
     .slice(2);
 
-  let language = getMetadata('og:locale');
+  const language = getMetadata('og:locale');
 
   const urlPrefix = `/${language}`;
   let accUrl = '';
@@ -198,6 +198,7 @@ export default async function decorate() {
     .then(async () => {
       // window.gnav_jsonPath = '/2022-nav-config.25.json';
       
+      const language = getMetadata('og:locale') || 'en-us';
       window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
 
       await Promise.all([

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -197,7 +197,9 @@ export default async function decorate() {
   await alternateHeaders()
     .then(async () => {
       // window.gnav_jsonPath = '/2022-nav-config.25.json';
-      window.gnav_jsonPath = 'https://www.esri.com/content/experience-fragments/esri-sites/en-us/site-settings/global-navigation-config/2022-nav-config.25.json';
+      
+      window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
+
       await Promise.all([
         loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),
         loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css'),

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -118,7 +118,7 @@ async function createBreadcrumbs() {
   const urlSegments = window.location.pathname.split('/')
     .slice(2);
 
-  const language = getMetadata('og:locale');
+  let language = getMetadata('og:locale');
 
   const urlPrefix = `/${language}`;
   let accUrl = '';

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -205,9 +205,6 @@ export default async function decorate() {
   setLocaleAndDirection();
   await alternateHeaders()
     .then(async () => {
-      // const language = getMetadata('og:locale') || 'en-us';
-      // window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
-
       await Promise.all([
         loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),
         loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css'),

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -188,14 +188,14 @@ function createSchema() {
 
 /**
  * Loads and decorates the header, mainly the navigation.
- * 
+ *
  * This function performs the following steps:
  * 1. Creates the schema for the webpage.
  * 2. Creates breadcrumbs for the webpage.
  * 3. Sets the locale and text direction based on metadata.
  * 4. Alternates headers based on the current page URL.
  * 5. Loads the global navigation script and CSS.
- * 
+ *
  * @param {Element} block The header block element
  * @returns {Promise<void>} A promise that resolves when the header is fully decorated.
  */

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -196,7 +196,8 @@ export default async function decorate() {
   setLocaleAndDirection();
   await alternateHeaders()
     .then(async () => {
-      window.gnav_jsonPath = '/2022-nav-config.25.json';
+      // window.gnav_jsonPath = '/2022-nav-config.25.json';
+      window.gnav_jsonPath = 'https://www.esri.com/content/experience-fragments/esri-sites/en-us/site-settings/global-navigation-config/2022-nav-config.25.json';
       await Promise.all([
         loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),
         loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css'),

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -196,8 +196,6 @@ export default async function decorate() {
   setLocaleAndDirection();
   await alternateHeaders()
     .then(async () => {
-      // window.gnav_jsonPath = '/2022-nav-config.25.json';
-      
       const language = getMetadata('og:locale') || 'en-us';
       window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
 

--- a/eds/blocks/header/header.js
+++ b/eds/blocks/header/header.js
@@ -119,7 +119,7 @@ async function createBreadcrumbs() {
     .slice(2);
 
   const language = getMetadata('og:locale');
-
+  window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
   const urlPrefix = `/${language}`;
   let accUrl = '';
   const accBreadcrumbs = [];
@@ -187,8 +187,17 @@ function createSchema() {
 }
 
 /**
- * loads and decorates the header, mainly the nav
+ * Loads and decorates the header, mainly the navigation.
+ * 
+ * This function performs the following steps:
+ * 1. Creates the schema for the webpage.
+ * 2. Creates breadcrumbs for the webpage.
+ * 3. Sets the locale and text direction based on metadata.
+ * 4. Alternates headers based on the current page URL.
+ * 5. Loads the global navigation script and CSS.
+ * 
  * @param {Element} block The header block element
+ * @returns {Promise<void>} A promise that resolves when the header is fully decorated.
  */
 export default async function decorate() {
   createSchema();
@@ -196,8 +205,8 @@ export default async function decorate() {
   setLocaleAndDirection();
   await alternateHeaders()
     .then(async () => {
-      const language = getMetadata('og:locale') || 'en-us';
-      window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
+      // const language = getMetadata('og:locale') || 'en-us';
+      // window.gnav_jsonPath = `https://www.esri.com/content/experience-fragments/esri-sites/${language}/site-settings/global-navigation-config/2022-nav-config.25.json`;
 
       await Promise.all([
         loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),


### PR DESCRIPTION
Using the language selector in the global nav, the global nav now fetches the correct language file. 

Fix #423 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://gnavlang--esri-eds--esri.aem.live/en-us/about/about-esri/overview
