### PR TITLE
Hero Banner align CTAs horizontally for desktop view

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -36,11 +36,6 @@
 
 .hero :where(h1, p) {
   inline-size: 90%;
-  margin-block-start: 0;
-}
-
-.hero p.description {
-  font-size: var(--font-0);
 }
 
 .hero p:has(+ p) {
@@ -49,7 +44,13 @@
 }
 
 .hero .button-container {
-  margin-block-start: var(--space-8);
+  margin-block: 0;
+  inline-size: auto;
+  display: inline-block;
+}
+
+.hero p.button-container a {
+  margin-block: var(--space-2);
 }
 
 .hero video {


### PR DESCRIPTION
Align CTAs horizontally in desktop view and stack CTAs in mobile view.

Fix #426 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/indoor-gis/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
- After: https://heroCTAs--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview

![mobileview](https://github.com/user-attachments/assets/d3c4ab38-3a53-474b-8f50-6c74a773be29)
![desktopview](https://github.com/user-attachments/assets/abb640e9-a8fc-4d14-ad78-d4eb8e41b446)
