### PR TITLE
Hero Banner Background Image Cover

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -72,6 +72,7 @@
 .hero .backgroundimage img {
   block-size: 100%;
   inline-size: 100%;
+  object-fit: cover;
 }
 
 .hero .image {


### PR DESCRIPTION
Background image compressed inwards needs object fix cover property.

Fix #432 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/spatial-analytics-data-science/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/spatial-analytics-data-science/overview
- After: https://heroBgImage--esri-eds--esri.aem.live/en-us/capabilities/spatial-analytics-data-science/overview

![compressed](https://github.com/user-attachments/assets/11a3189f-cf81-4b9d-8841-38d1b3d4649e)
![www](https://github.com/user-attachments/assets/5c7c799c-7d8d-4f0f-8313-95505b5b7138)
