### PR TITLE
feat: update icon sizing

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -299,7 +299,7 @@ main {
     inline-size: 24px;
   }
 
-  .icon[class$="-48"] {
+  .icon:where([class$="-48"], [class$="-64"]) {
     block-size: 48px;
     inline-size: 48px;
   }


### PR DESCRIPTION
Not ideal, but adding `-64` to the sizing rule. 

Fix #437

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
- After: https://iconsize--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
