### PR TITLE
Storyteller add logic for no poster image

### DIFF
--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -223,12 +223,15 @@ function enableVideoControls(block) {
 }
 
 export default async function decorate(block) {
+  let foregroundSrc = '';
   const pTags = block.querySelectorAll('p');
   const pictureTagLeft = pTags[0].querySelector('picture');
   const vidUrls = getMP4(block);
   const foregroundContentContainer = document.createElement('div');
-  const foregroundPicture = block.querySelectorAll('picture')[1];
-  const foregroundSrc = foregroundPicture.querySelector('img').src;
+  const foregroundPicture = block.querySelectorAll('picture');
+  if (foregroundPicture.length > 1) {
+    foregroundSrc = foregroundPicture[1].querySelector('img').src;
+  }
   const foregroundContent = document.createElement('div');
   const videoBtn = await getVideoBtn();
 
@@ -236,8 +239,8 @@ export default async function decorate(block) {
   let videoTag = video();
 
   foregroundContent.classList.add('content-wrapper');
-  if (isMP4(vidUrls) === true) {
-    foregroundPicture.classList.add('hide-poster');
+  if ((isMP4(vidUrls) === true) && (foregroundPicture.length > 1)) {
+    foregroundPicture[1].classList.add('hide-poster');
   }
   if ((pictureTagLeft !== null)) {
     setforegroundContainers(block);


### PR DESCRIPTION
Add logic for no poster image. **A thorough JS / CSS cleanup to follow**

Fix #445 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://noPoster--esri-eds--esri.aem.live/en-us/about/about-esri/overview

![broken](https://github.com/user-attachments/assets/30f2725a-3151-4fef-bb70-1385ef898d3b)

![fix](https://github.com/user-attachments/assets/ac56c38d-6687-4676-b06c-ec7139266fed)
