### PR TITLE
Hero Banner small center variant

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -7,8 +7,8 @@
   padding-block-end: 32px;
 }
 
-.columns > div > div:last-child > * {
-  padding-inline: 6.7%;
+.columns > div > div :where(h2, p) {
+  padding: 0 var(--space-8);
 }
 
 .columns > div > .columns-img-col {
@@ -38,6 +38,10 @@
 
   .columns > div > div {
     flex: 1;
+  }
+
+  .columns > div > div :where(h2, p) {
+    padding: 0 var(--space-16);
   }
 }
 

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -7,8 +7,8 @@
   padding-block-end: 32px;
 }
 
-.columns > div > div :where(h2, p) {
-  padding: 0 var(--space-8);
+.columns > div > div:last-child > * {
+  padding-inline: 6.7%;
 }
 
 .columns > div > .columns-img-col {
@@ -38,10 +38,6 @@
 
   .columns > div > div {
     flex: 1;
-  }
-
-  .columns > div > div :where(h2, p) {
-    padding: 0 var(--space-16);
   }
 }
 

--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -122,4 +122,8 @@
   .hero :where(h1, p) {
     inline-size: 90%;
   }
+
+  .hero.small.center :is(.image, .content) {
+    inline-size: auto;
+  }
 }

--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -34,8 +34,12 @@
   font-size: var(--font-6);
 }
 
+.hero.small.center .content {
+  text-align: center;
+}
+
 .hero :where(h1, p) {
-  inline-size: 90%;
+  inline-size: 100%;
 }
 
 .hero p:has(+ p) {
@@ -95,6 +99,10 @@
   aspect-ratio: 3 / 2;
 }
 
+.hero.small picture img {
+  aspect-ratio: 16 / 9;
+}
+
 @media (width >= 1024px) {
   .hero {
     align-items: center;
@@ -109,5 +117,9 @@
   .hero :is(.image, .content) {
     inline-size: 50%;
     max-inline-size: 700px;
+  }
+
+  .hero :where(h1, p) {
+    inline-size: 90%;
   }
 }


### PR DESCRIPTION
Enable Small and Center text variant. 

Fix #451 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/3d-gis/resources
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/resources
- After: https://smallHero--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/resources

![parameters](https://github.com/user-attachments/assets/6f4de4a7-0089-4973-8294-de9a25477b6b)
@alexcarol we have a backgroundimg 'null' value.

![heromobile](https://github.com/user-attachments/assets/1f2e8874-1683-44ff-a3af-ad43565ed967)

![wwwherosmall](https://github.com/user-attachments/assets/58526bd8-5ee5-4725-ad10-480db01c9c62)
