### PR TITLE
Column / 50-50 & Media Split add start/end padding 

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -26,10 +26,6 @@
   margin: 0 var(--space-8);
 }
 
-.columns.media-split picture img {
-  margin: auto;
-}
-
 .columns.calcite-mode-gray {
   background-color: var(--calcite-ui-foreground-2);
 }

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -8,8 +8,12 @@
 }
 
 .columns > div > div :where(h2, p) {
-  padding: 0 var(--space-8);
+  margin: 0 var(--space-8);
 }
+
+/* .columns > div > div:nth-of-type(2) :where(h2, p) {
+  margin: 0 var(--space-8);
+} */
 
 .columns > div > .columns-img-col {
   display: block;
@@ -40,8 +44,14 @@
     flex: 1;
   }
 
+  .columns > div > div:nth-of-type(2) :where(h2, p)  {
+    margin-inline: 0 auto;
+  }
+  
   .columns > div > div :where(h2, p) {
-    padding: 0 var(--space-16);
+    max-inline-size: 720px;
+    margin-inline-start: auto;
+    padding-inline: var(--space-12);
   }
 }
 

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -11,10 +11,6 @@
   margin: 0 var(--space-8);
 }
 
-/* .columns > div > div:nth-of-type(2) :where(h2, p) {
-  margin: 0 var(--space-8);
-} */
-
 .columns > div > .columns-img-col {
   display: block;
   block-size: 100%;
@@ -24,6 +20,14 @@
   display: block;
   block-size: 100%;
   object-fit: cover;
+}
+
+.columns > div > div :where(h2, p) {
+  margin: 0 var(--space-8);
+}
+
+.columns.media-split picture img {
+  margin: auto;
 }
 
 .columns.calcite-mode-gray {

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -22,10 +22,6 @@
   object-fit: cover;
 }
 
-.columns > div > div :where(h2, p) {
-  margin: 0 var(--space-8);
-}
-
 .columns.calcite-mode-gray {
   background-color: var(--calcite-ui-foreground-2);
 }

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -7,8 +7,8 @@
   padding-block-end: 32px;
 }
 
-.columns > div > div:last-child > * {
-  padding-inline: 6.7%;
+.columns > div > div :where(h2, p) {
+  padding: 0 var(--space-8);
 }
 
 .columns > div > .columns-img-col {
@@ -38,6 +38,10 @@
 
   .columns > div > div {
     flex: 1;
+  }
+
+  .columns > div > div :where(h2, p) {
+    padding: 0 var(--space-16);
   }
 }
 


### PR DESCRIPTION
Adding a gutter for fifty fifty / Column Block. Will adjust aligned for image in separate PR. 

![50spt](https://github.com/user-attachments/assets/07589a70-31e8-4ace-aa66-0eb046400250)

Fix #454

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/data-management (50/50)
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management  (50/50)
- After: https://fiftyGutter--esri-eds--esri.aem.live/en-us/capabilities/data-management  (50/50)

- Original: https://www.esri.com/en-us/capabilities/data-management (Media Split)
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management  (Media Split)
- After: https://fiftyGutter--esri-eds--esri.aem.live/en-us/capabilities/data-management  (Media Split)


![fifty-lr](https://github.com/user-attachments/assets/4937f663-22a9-46b5-a734-3b8b1fa8b239)
![mediasplit-LR](https://github.com/user-attachments/assets/b6f09b86-aee0-47a7-92fe-73c8ec081cb7)

