### PR TITLE
fix(ui): updated spacing between title and description for cards default

### DIFF
--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -20,6 +20,7 @@
       line-height: 1.375;
       margin-block-end: 0;
       font-weight: 400;
+      margin-block-end: var(--space-2);
     }
 
     p:last-child {

--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -18,7 +18,6 @@
     h3 {
       font-size: var(--title-size);
       line-height: 1.375;
-      margin-block-end: 0;
       font-weight: 400;
       margin-block-end: var(--space-2);
     }


### PR DESCRIPTION


Fix #440 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/indoor-gis/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
- After: https://cardspcaing--esri-eds--esri.aem.page/en-us/capabilities/indoor-gis/overview
