### PR TITLE
Column /  50-50 & Media Split bottom top padding mobile view

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -16,6 +16,10 @@
   block-size: 100%;
 }
 
+.columns > div > :not(.columns-img-col) {
+  padding: var(--space-16) 0 var(--space-20);
+}
+
 .columns > div > .columns-img-col img {
   display: block;
   block-size: 100%;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #457 

![50spt](https://github.com/user-attachments/assets/98231de5-7e0f-4667-993f-94c675d935af)


Test URLs:
- Original: https://www.esri.com/en-us/capabilities/data-management **(50/50)**
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management **(50/50)**
- After: https://colTopPad--esri-eds--esri.aem.live/en-us/capabilities/data-management  **(50/50)**

- Original: https://www.esri.com/en-us/capabilities/data-management **(Media Split)**
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management **(Media Split)**
- After: https://colTopPad--esri-eds--esri.aem.live/en-us/capabilities/data-management  **(Media Split)**

![50padding](https://github.com/user-attachments/assets/a5dbf65e-631e-48af-8206-2ebf1f7d2f1b)

![paddingms](https://github.com/user-attachments/assets/a15a2427-1e23-4e9b-ad9d-e4086f793ea7)

