### PR TITLE
feat(ui): updated title for the cards to be h3

### DIFF
--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -67,7 +67,6 @@ export default function decorate(block) {
           const h3 = document.createElement('h3');
           h3.innerHTML = p.innerHTML;
           p.replaceWith(h3);
-          console.log('replaced' + h3.innerHTML);
         });
       }
       if (block.classList.contains('standard')) processStandardCard(element);

--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -62,6 +62,14 @@ export default function decorate(block) {
     [...li.children].forEach((element) => {
       if (element.children.length === 1 && element.querySelector('picture')) element.className = 'cards-card-image';
       else { element.className = 'cards-card-body'; }
+      if (!block.classList.contains('simple')) {
+        element.querySelectorAll('p:not(:has(img, a)):nth-last-child(2)').forEach((p) => {
+          const h3 = document.createElement('h3');
+          h3.innerHTML = p.innerHTML;
+          p.replaceWith(h3);
+          console.log('replaced' + h3.innerHTML);
+        });
+      }
       if (block.classList.contains('standard')) processStandardCard(element);
     });
     if (block.classList.contains('simple')) processSimpleCard(li);


### PR DESCRIPTION
Modified JS to update the title element to H3 for all versions of cards. 

Fix #429 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/data-management
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management
- After: https://cardtitleupdate--esri-eds--esri.aem.live/en-us/capabilities/data-management

- Original: https://www.esri.com/en-us/capabilities/field-operations/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
- After: https://cardtitleupdate--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
