### PR TITLE
style(css): reformat CSS with stylelint to fix linter errors

### DIFF
--- a/eds/blocks/call-to-action/call-to-action.css
+++ b/eds/blocks/call-to-action/call-to-action.css
@@ -3,10 +3,10 @@
 }
 
 .call-to-action-wrapper {
-  color: var(--calcite-ui-text-1);
-  padding: var(--space-24) 0 var(--space-32);
   background: var(--calcite-ui-foreground-1);
+  color: var(--calcite-ui-text-1);
   justify-content: center;
+  padding: var(--space-24) 0 var(--space-32);
 }
 
 .call-to-action {
@@ -19,13 +19,13 @@
     inline-size: 100%;
 
     > div {
-      flex: 1;
-      display: flex;
       align-items: center;
-      flex-direction: column;
-      justify-content: center;
       block-size: var(--space-56);
       border-inline-end: 0.01rem solid var(--calcite-ui-border-1);
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      justify-content: center;
       margin-inline-end: -0.01rem;
 
       &:last-child {
@@ -42,8 +42,8 @@
 }
 
 p.button-container .button {
-  margin-inline-end: 0;
   margin-block-start: 0;
+  margin-inline-end: 0;
 }
 
 .call-to-action.fragment {
@@ -68,15 +68,15 @@ p.button-container .button {
     }
 
     > div:first-child {
-      display: block;
       border-inline-end: none;
+      display: block;
       margin-inline-end: 0;
 
       span.icon {
-        display: block;
-        margin: auto;
-        inline-size: 64px;
         block-size: 64px;
+        display: block;
+        inline-size: 64px;
+        margin: auto;
       }
 
       span.icon > img {
@@ -85,15 +85,14 @@ p.button-container .button {
     }
 
     > div:nth-child(2) {
+      block-size: max-content;
       display: grid;
       grid-template-columns: 50vw 50vw;
+      margin: 0;
 
       .cards ul {
         inline-size: 100%;
       }
-
-      margin: 0;
-      block-size: max-content;
 
       span.icon > img {
         filter: var(--sepia-icon-color);
@@ -101,8 +100,8 @@ p.button-container .button {
     }
 
     > div:nth-child(3) {
-      display: block;
       block-size: auto;
+      display: block;
     }
   }
 
@@ -118,11 +117,11 @@ p.button-container .button {
   }
 
   .call-to-action > div > div {
+    border-block-end: 0.01rem solid var(--calcite-ui-border-1);
+    border-inline-end: none;
     inline-size: 100%;
     margin-block: var(--space-10);
-    border-inline-end: none;
     margin-inline-end: 0;
-    border-block-end: 0.01rem solid var(--calcite-ui-border-1);
   }
 
   .call-to-action > div > div:last-child {

--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -19,7 +19,7 @@
   .cards-card-body {
     margin: 8px;
 
-h3 {
+    h3 {
       font-size: var(--title-size);
       font-weight: 400;
       line-height: 1.375;
@@ -32,7 +32,7 @@ h3 {
       margin-block-end: 1.5rem;
     }
 
-    p a{
+    p a {
       margin-block-start: 0;
     }
 
@@ -118,7 +118,7 @@ h3 {
     --cards-per-row: 3;
   }
 
-  .cardsperrow-4 > ul > li{
+  .cardsperrow-4 > ul > li {
     --cards-per-row: 4;
   }
 
@@ -191,18 +191,18 @@ h3 {
 .cards.simple.centered li .cards-card-body .card-body-content {
   justify-content: center;
 
-p {
+  p {
     text-align: center;
   }
 }
 
 /* Cards Standard */
-.cards.standard li{
+.cards.standard li {
   display: flex;
   position: relative;
 }
 
-.cards.standard .cards-card-body{
+.cards.standard .cards-card-body {
   background-color: var(--calcite-ui-foreground-1);
   border: 1px solid var(--calcite-ui-border-1);
   display: flex;
@@ -250,8 +250,8 @@ p {
     }
   }
 
-  .card-body-title,.card-body-subtitle,p:last-child {
-    margin:0;
+  .card-body-title, .card-body-subtitle, p:last-child {
+    margin: 0;
     padding-inline: var(--space-5);
   }
 
@@ -262,7 +262,7 @@ p {
     font-size: var(--title-size);
     -webkit-line-clamp: 4;
     line-clamp: 4;
-    margin-block-end:  var(--space-3);
+    margin-block-end: var(--space-3);
     overflow: hidden;
     text-align: start;
   }
@@ -292,7 +292,7 @@ p {
     inline-size: 100%;
     padding-block-end: var(--space-5);
 
-img {
+    img {
       block-size: auto;
       inline-size: 100%;
     }
@@ -310,7 +310,7 @@ img {
 }
 
 .cards.centered {
- text-align: center;
+  text-align: center;
 }
 
 .cards.centered .cards-card-body {
@@ -319,7 +319,7 @@ img {
   }
 }
 
-.cards.simple .cards-card-body:is(:hover,:focus-within){
+.cards.simple .cards-card-body:is(:hover,:focus-within) {
   border: 1px solid var(--calcite-ui-brand);
 }
 

--- a/eds/blocks/centered-content-switcher/centered-content-switcher.css
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.css
@@ -1,34 +1,34 @@
 .centered-content-switcher {
-  padding: 0;
-  block-size: 100%;
-  box-sizing: border-box;
   animation-duration: 550ms;
   animation-timing-function: ease;
+  block-size: 100%;
+  box-sizing: border-box;
+  padding: 0;
 
   .mobile-nav {
-    display: flex;
-    justify-content: center;
     align-items: center;
-    padding: var(--space-4) 0;
-    border-block-start: 1px solid var(--calcite-ui-border-1);
-    margin-block-start: 0;
     animation-delay: 200ms;
     animation-duration: 550ms;
     animation-timing-function: ease;
+    border-block-start: 1px solid var(--calcite-ui-border-1);
+    display: flex;
+    justify-content: center;
+    margin-block-start: 0;
+    padding: var(--space-4) 0;
 
     ul {
-      list-style-type: none;
-      display: flex;
-      justify-content: center;
       align-items: center;
-      padding: 0;
+      display: flex;
       gap: 16px;
+      justify-content: center;
+      list-style-type: none;
+      padding: 0;
 
       li {
         block-size: 10px;
-        inline-size: 10px;
-        border-radius: 50%;
         border: 1px solid var(--calcite-ui-text-1);
+        border-radius: 50%;
+        inline-size: 10px;
       }
 
       li.active {
@@ -39,34 +39,34 @@
   }
 
   .desktop-nav {
-    display: none;
-    border-block-start: 1px solid var(--calcite-ui-border-1);
-    margin-block-start: 0;
-    padding: 0;
     animation-delay: 200ms;
     animation-duration: 550ms;
     animation-timing-function: ease;
+    border-block-start: 1px solid var(--calcite-ui-border-1);
+    display: none;
+    margin-block-start: 0;
+    padding: 0;
 
     ul {
-      list-style-type: none;
+      align-items: center;
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       justify-content: center;
-      align-items: center;
+      list-style-type: none;
       margin: 0;
       padding: 0;
 
       li {
+        align-items: center;
         display: grid;
         grid-template-columns: calc(64px + 2 * var(--space-2)) 1fr;
-        align-items: center;
         outline: 1px solid var(--calcite-ui-border-1);
       }
 
       li picture {
+        align-items: center;
         block-size: 100%;
         display: flex;
-        align-items: center;
         justify-content: center;
       }
 
@@ -79,13 +79,13 @@
       }
 
       li p {
+        font-size: var(--font-0);
+        line-height: normal;
         margin: 0;
         margin-inline-start: var(--space-4);
-        padding-inline-end: var(--space-3);
         overflow: hidden;
-        font-size: var(--font-0);
         padding-block: var(--space-3);
-        line-height: normal;
+        padding-inline-end: var(--space-3);
       }
 
       li.active {
@@ -105,47 +105,47 @@
   }
 
   & > div {
-    background-position: center;
-    background-size: cover;
-    box-sizing: border-box;
-    padding: var(--space-10) 0;
-    block-size: 100%;
-    display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    transition: all linear .5s;
     animation-duration: 550ms;
     animation-timing-function: ease;
+    background-position: center;
+    background-size: cover;
+    block-size: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: var(--space-10) 0;
+    transition: all linear .5s;
 
     & > div {
-      inline-size: 1440px;
-      max-inline-size: 96vw;
       background-color: var(--esri-ui-opacity90);
+      inline-size: 1440px;
       margin: auto;
+      max-inline-size: 96vw;
     }
 
     & > div:first-child {
-      background-color: var(--esri-ui-opacity90);
-      box-sizing: border-box;
-      padding: var(--space-12) var(--space-2);
-      min-block-size: 350px;
-      display: flex;
-      flex-direction: column;
       align-items: center;
-      justify-content: center;
-      text-align: center;
-      margin-block-end: 0;
       animation-delay: 100ms;
       animation-duration: 550ms;
       animation-timing-function: ease;
+      background-color: var(--esri-ui-opacity90);
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      margin-block-end: 0;
+      min-block-size: 350px;
+      padding: var(--space-12) var(--space-2);
+      text-align: center;
 
       & > p {
-        padding-block-start: var(--space-5);
-        font-weight: var(--calcite-font-weight-bold);
         color: var(--calcite-ui-text-2);
         font-size: var(--font-minus-2);
+        font-weight: var(--calcite-font-weight-bold);
         margin-block: 0 var(--space-2);
+        padding-block-start: var(--space-5);
       }
 
       & > p:first-child {
@@ -159,15 +159,15 @@
       & > h2 {
         color: var(--calcite-ui-text-1);
         font-size: var(--font-4);
-        margin-block-end: var(--space-2);
         font-weight: var(--calcite-font-weight-normal);
-        margin: 0 0 var(--space-4);
         line-height: 1.375;
+        margin: 0 0 var(--space-4);
+        margin-block-end: var(--space-2);
       }
     }
   }
 
-  & > div[aria-hidden='true'] {
+  & > div[aria-hidden="true"] {
     opacity: 0;
     pointer-events: none;
     position: absolute;
@@ -181,13 +181,13 @@
 @media (width >= 480px) {
   .centered-content-switcher {
     & > div {
-      min-block-size: 675px;
-      max-block-size: 990px;
       inline-size: 100%;
+      max-block-size: 990px;
+      min-block-size: 675px;
 
       & > div {
         inline-size: 1200px;
-        max-inline-size: 80vw;      
+        max-inline-size: 80vw;
       }
     }
   }

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -19,13 +19,13 @@
 }
 
 .columns > div > .columns-img-col {
-  display: block;
   block-size: 100%;
+  display: block;
 }
 
 .columns > div > .columns-img-col img {
-  display: block;
   block-size: 100%;
+  display: block;
   object-fit: cover;
 }
 
@@ -50,29 +50,29 @@
     flex: 1;
   }
 
-  .columns > div > div:nth-of-type(2) :where(h2, p)  {
+  .columns > div > div:nth-of-type(2) :where(h2, p) {
     margin-inline: 0 auto;
   }
-  
+
   .columns > div > div :where(h2, p) {
-    max-inline-size: 720px;
     margin-inline-start: auto;
+    max-inline-size: 720px;
     padding-inline: var(--space-12);
   }
 }
 
 .columns.media-split {
   & > div > div:first-child {
-    padding-inline: 0;
     margin-block: 0;
+    padding-inline: 0;
   }
 
   & > div > div p:first-child {
-    font-weight: var(--calcite-font-weight-bold);
-    text-transform: uppercase;
     color: var(--calcite-ui-text-2);
     font-size: var(--font-minus-2);
+    font-weight: var(--calcite-font-weight-bold);
     margin-block-end: var(--space-2);
+    text-transform: uppercase;
   }
 
   & > div > div h2 {

--- a/eds/blocks/form/form.css
+++ b/eds/blocks/form/form.css
@@ -1,11 +1,11 @@
 .form.block {
-  color: var(--calcite-ui-text-1);
   background-color: var(--calcite-ui-foreground-1);
+  color: var(--calcite-ui-text-1);
 
   & > div.one-form {
     inline-size: 1440px;
-    max-inline-size: 96vw;
     margin: auto;
+    max-inline-size: 96vw;
 
     & div:first-child {
       h2 {

--- a/eds/blocks/header/header.css
+++ b/eds/blocks/header/header.css
@@ -1,13 +1,13 @@
 /* remove styles coming from styles.css */
 /* stylelint-disable */
 .gnav_top-nav_language-chooser-button {
-    margin: unset;
+  margin: unset;
 }
 
 .gnav_top-nav_language-chooser-button:focus {
-    background-color: unset;
+  background-color: unset;
 }
 
 div#globalfooter {
-    color: var(--calcite-ui-text-1);
+  color: var(--calcite-ui-text-1);
 }

--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -48,9 +48,9 @@
 }
 
 .hero .button-container {
-  margin-block: 0;
-  inline-size: auto;
   display: inline-block;
+  inline-size: auto;
+  margin-block: 0;
 }
 
 .hero p.button-container a {

--- a/eds/blocks/image-switcher/image-switcher.css
+++ b/eds/blocks/image-switcher/image-switcher.css
@@ -1,23 +1,23 @@
 .image-switcher .nav {
+  align-items: center;
   display: flex;
   justify-content: center;
-  align-items: center;
   margin: auto;
 
   .nav-list {
-    text-decoration: none;
-    list-style-type: none;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    list-style-type: none;
     padding: 0;
+    text-decoration: none;
 
     .nav-item {
+      align-items: center;
       block-size: 64px;
       border: 1px solid var(--calcite-ui-border-1);
       display: flex;
       justify-content: center;
-      align-items: center;
       transition: background-color 180ms, box-shadow 180ms;
     }
 
@@ -30,15 +30,15 @@
     }
 
     picture {
-      inline-size: 48px;
       block-size: 48px;
+      inline-size: 48px;
 
       img {
-        inline-size: 48px;
         block-size: 48px;
+        border-radius: 50%;
+        inline-size: 48px;
         object-fit: cover;
         object-position: center;
-        border-radius: 50%;
       }
     }
   }
@@ -48,13 +48,13 @@
   padding: var(--space-5);
 
   div {
-    max-inline-size: 600px;  
+    max-inline-size: 600px;
   }
 
   h2 {
     font-size: var(--font-4);
-    line-height: 1.375;
     font-weight: 400;
+    line-height: 1.375;
     margin-block: 0 var(--space-2);
   }
 
@@ -68,15 +68,15 @@
 
   h3 {
     font-size: 16px;
-    line-height: 20px;
     font-weight: 300;
+    line-height: 20px;
     margin-block-start: 0;
   }
 
   p {
+    color: var(--calcite-ui-text-2);
     font-size: 15px;
-    line-height: 20px;
-    color: var(--calcite-ui-text-2)
+    line-height: 20px
   }
 
   calcite-link {
@@ -85,36 +85,36 @@
   }
 
   & > div {
-    position: relative;
     block-size: 100%;
+    position: relative;
   }
-  
+
   & > div[aria-hidden="true"] {
     display: none;
   }
 
   .image-div {
-    position: absolute;
-    inset-block-start: 0;
-    inset-inline-start: 0;
     block-size: 100%;
     inline-size: 100%;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    position: absolute;
   }
 
   .image-content {
-    position: absolute;
+    background-color: var(--esri-ui-opacity97-inverse);
     inset-block-start: 0;
     inset-inline-start: 0;
-    z-index: 3;
-    background-color: var(--esri-ui-opacity97-inverse);
     margin: var(--space-10);
     padding: var(--space-8);
+    position: absolute;
+    z-index: 3;
   }
 
   img {
-    object-fit: cover;
     block-size: 100%;
     inline-size: 100%;
+    object-fit: cover;
   }
 }
 
@@ -122,8 +122,8 @@
   .image-switcher .images {
     h3 {
       font-size: 24px;
-      line-height: 30px;
       font-weight: 300;
+      line-height: 30px;
     }
 
     p {
@@ -140,9 +140,9 @@
 
 @media (width >= 1096px) {
   .image-switcher {
+    block-size: 950px;
     display: flex;
     flex-direction: row-reverse;
-    block-size: 950px;
   }
 
   .image-switcher.flip {
@@ -157,20 +157,20 @@
 
   .image-switcher .images {
     .image-content {
+      inset-block: auto 0;
+      inset-inline-end: 0;
       margin: auto auto var(--space-24);
       max-inline-size: 82%;
       padding: var(--space-8);
-      inset-inline-end: 0;
-      inset-block: auto 0;
     }
   }
 
   .image-switcher .content {
-    padding: var(--space-20);
+    align-items: center;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
+    padding: var(--space-20);
   }
 
   .image-switcher .nav {
@@ -183,8 +183,8 @@
 
       .nav-item {
         block-size: auto;
-        padding: var(--space-3) var(--space-3) var(--space-3) var(--space-6);
         justify-content: flex-start;
+        padding: var(--space-3) var(--space-3) var(--space-3) var(--space-6);
       }
 
       .nav-item.active, .nav-item:hover {
@@ -192,24 +192,24 @@
       }
 
       picture {
-        inline-size: 60px;
         block-size: 60px;
+        inline-size: 60px;
         margin-inline-end: var(--space-5);
 
         img {
-          inline-size: 60px;
           block-size: 60px;
+          inline-size: 60px;
         }
       }
 
       p {
-        display: block;
         color: var(--calcite-ui-text-2);
-        text-align: start;
-        font-size: var(--font-0);
         cursor: pointer;
+        display: block;
+        font-size: var(--font-0);
         margin-block: auto;
         padding-inline: 0;
+        text-align: start;
       }
     }
   }

--- a/eds/blocks/large-content-stack/large-content-stack.css
+++ b/eds/blocks/large-content-stack/large-content-stack.css
@@ -1,35 +1,35 @@
 .large-content-stack.block {
-  padding: 0;
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
+  padding: 0;
   text-align: center;
 
   .media-wrapper {
+    inline-size: 92%;
     margin: var(--space-10) auto 0;
     max-inline-size: 1050px;
-    inline-size: 92%;
     position: relative;
   }
 
   .video-play-anchor {
-    position: absolute;
     inset-block-start: 50%;
     inset-inline-start: 50%;
+    position: absolute;
     transform: translate(-50%, -50%);
   }
 
   h2 {
+    font-size: var(--font-4);
+    font-weight: var(--calcite-font-weight-normal);
     inline-size: 90%;
     margin: 0 auto;
     padding-block-start: var(--space-10);
-    font-size: var(--font-4);
-    font-weight: var(--calcite-font-weight-normal);
   }
 
   p {
-    margin-inline: auto;
     inline-size: 90%;
+    margin-inline: auto;
   }
 
   .button-container {

--- a/eds/blocks/local-navigation/local-navigation.css
+++ b/eds/blocks/local-navigation/local-navigation.css
@@ -6,23 +6,23 @@
 }
 
 .local-navigation.block {
-  block-size: 60px;
   background-color: inherit;
+  block-size: 60px;
 }
 
 .local-navigation nav#main {
+  align-items: flex-start;
   display: flex;
   margin-inline-start: var(--space-4);
-  align-items: flex-start;
 }
 
 .local-navigation .navigation-title a {
+  align-items: center;
+  block-size: 60px;
   color: #fff;
   display: flex;
-  block-size: 60px;
-  align-items: center;
-  white-space: nowrap;
   font-size: var(--font-0);
+  white-space: nowrap;
 }
 
 .local-navigation .navigation-title a:hover {
@@ -30,57 +30,57 @@
 }
 
 .local-navigation ul.mobile-menu {
-  padding: 0;
   inline-size: 100%;
-  position: absolute;
+  inset-block-start: 60px;
   inset-inline-end: 0;
   list-style-type: none;
-  inset-block-start: 60px;
+  padding: 0;
+  position: absolute;
 }
 
-.local-navigation ul.mobile-menu[aria-expanded='false'] {
+.local-navigation ul.mobile-menu[aria-expanded="false"] {
   display: none;
 }
 
 .local-navigation ul li a {
-  color: #fff;
-  display: flex;
-  cursor: pointer;
-  block-size: 60px;
   align-items: center;
-  text-decoration: none;
   background-color: #202020;
+  block-size: 60px;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
   padding-inline: var(--space-6);
+  text-decoration: none;
 }
 
-.local-navigation ul li a:is([aria-current='true'], :hover) {
+.local-navigation ul li a:is([aria-current="true"], :hover) {
   background-color: #2b2b2b;
 }
 
-.local-navigation ul li.page-title > button[aria-current='true'] {
+.local-navigation ul li.page-title > button[aria-current="true"] {
   background-color: #202020;
 
   /* box-shadow: inset 3px 0 0 0 var(--calcite-ui-brand); */
   filter: drop-shadow(0 0 0 var(--theme-color));
 }
 
-.local-navigation ul li a[aria-current='true'] {
+.local-navigation ul li a[aria-current="true"] {
   /* box-shadow: inset 3px 0 0 0 var(--calcite-ui-brand); */
   filter: drop-shadow(3px 0 0 var(--theme-color));
 }
 
 .local-navigation ul li button {
+  align-items: center;
+  background-color: #202020;
+  block-size: 60px;
   border: none;
   color: #fff;
-  display: flex;
   cursor: pointer;
-  block-size: 60px;
+  display: flex;
+  font-size: var(--font-0);
   inline-size: 100%;
-  align-items: center;
   margin-block-start: 0;
   text-decoration: none;
-  font-size: var(--font-0);
-  background-color: #202020;
 }
 
 .local-navigation ul li button:hover {
@@ -88,73 +88,73 @@
   box-shadow: inset 0 0 0 0 var(--calcite-link-blue-underline);
 }
 
-.local-navigation ul.mobile-menu .subnav[aria-hidden='true'] {
+.local-navigation ul.mobile-menu .subnav[aria-hidden="true"] {
   display: none;
 }
 
 .local-navigation ul.mobile-menu button::after {
   block-size: 13px;
+  content: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 25' width='10' height='25'%3E%3Cpath fill='%23ffffff' d='M 0 0 14 0 7 7' /%3E%3C/svg%3E");
+  inset-inline-end: var(--space-4);
   position: absolute;
   transition-duration: 0.25s;
-  inset-inline-end: var(--space-4);
-  content: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 25' width='10' height='25'%3E%3Cpath fill='%23ffffff' d='M 0 0 14 0 7 7' /%3E%3C/svg%3E");
 }
 
-.local-navigation ul.mobile-menu button[aria-expanded='true']::after {
-  transition-duration: 0.25s;
+.local-navigation ul.mobile-menu button[aria-expanded="true"]::after {
   transform: rotateX(180deg) translateY(1px);
+  transition-duration: 0.25s;
 }
 
 .local-navigation calcite-icon {
-  z-index: 3001;
-  color: #fff;
   block-size: 60px;
+  color: #fff;
   cursor: pointer;
-  position: absolute;
   margin: auto 0 auto 90%;
+  position: absolute;
+  z-index: 3001;
 }
 
 .local-navigation .subnav {
-  position: relative;
-  inset-inline-end: 0;
   background-color: #202020;
+  inset-inline-end: 0;
+  position: relative;
 }
 
 .local-navigation .subnav .subnav-ul a {
-  color: #9f9f9f;
-  white-space: nowrap;
-  background-size: 200% 1px;
-  background-repeat: no-repeat;
-  background-position: 100% 100%;
-  transition: background-position .25s;
   background-image: linear-gradient(90deg, #007ac2 50%, #555 0);
+  background-position: 100% 100%;
+  background-repeat: no-repeat;
+  background-size: 200% 1px;
+  color: #9f9f9f;
+  transition: background-position .25s;
+  white-space: nowrap;
 }
 
 .local-navigation .subnav .subnav-ul a:hover {
-  background-position: 0 100%;
   background-color: #202020;
+  background-position: 0 100%;
 }
 
 .local-navigation .subnav .subnav-ul a::after {
-  opacity: 0;
-  display: flex;
   block-size: 16px;
+  content: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath fill='%23007ac2' d='M8 14.3l5.3-5.3H0V8h13.3L8 2.7V1.3L15.2 8.5 8 15.7V14.3z' /%3E%3C/svg%3E");
+  display: flex;
   inline-size: 100%;
+  inset-inline-end: .20px;
   justify-content: end;
   margin-inline-end: 20px;
-  inset-inline-end: .20px;
+  opacity: 0;
   transition: all .25s ease-out;
-  content: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath fill='%23007ac2' d='M8 14.3l5.3-5.3H0V8h13.3L8 2.7V1.3L15.2 8.5 8 15.7V14.3z' /%3E%3C/svg%3E");
 }
 
 .local-navigation .subnav .subnav-ul a:hover::after {
-  opacity: 1;
   margin-inline-end: 10px;
+  opacity: 1;
 }
 
 .local-navigation .subnav .subnav-ul {
-  margin: 0;
   list-style-type: none;
+  margin: 0;
   padding-inline-start: var(--space-10);
 }
 
@@ -163,10 +163,10 @@
 }
 
 .local-navigation calcite-button {
-  display: flex;
-  padding-inline: 30%;
   background-color: #202020;
+  display: flex;
   padding-block: var(--space-4);
+  padding-inline: 30%;
 }
 
 @media (width >= 616px) {
@@ -185,18 +185,18 @@
   }
 
   .local-navigation ul.mobile-menu {
-    margin: 0;
     inline-size: 100%;
-    position: relative;
     inset-block-start: 0;
     justify-content: end;
+    margin: 0;
+    position: relative;
   }
 
   .local-navigation ul li a {
     background-color: #2b2b2b;
   }
 
-  .local-navigation ul li a[aria-current='true'] {
+  .local-navigation ul li a[aria-current="true"] {
     background-color: #202020;
     box-shadow: inset 0 -3px 0 0 var(--calcite-ui-brand);
   }
@@ -210,20 +210,20 @@
     box-shadow: inset 0 -3px 0 0 var(--calcite-link-blue-underline);
   }
 
-  .local-navigation ul li.page-title > button[aria-current='true'] {
+  .local-navigation ul li.page-title > button[aria-current="true"] {
     box-shadow: inset 0 -3px 0 0 var(--calcite-ui-brand);
   }
 
   .local-navigation ul.mobile-menu button::after {
-    position: relative;
     inset-inline-start: var(--space-2);
+    position: relative;
   }
 
-  .local-navigation ul.mobile-menu[aria-expanded='false'] {
+  .local-navigation ul.mobile-menu[aria-expanded="false"] {
+    align-items: flex-end;
+    block-size: 60px;
     display: flex;
     flex-wrap: nowrap;
-    block-size: 60px;
-    align-items: flex-end;
   }
 
   .local-navigation ul li button {
@@ -236,8 +236,8 @@
   }
 
   .local-navigation .subnav {
-    position: absolute;
     inline-size: 330px;
+    position: absolute;
   }
 
   .local-navigation .subnav .subnav-ul {
@@ -249,8 +249,8 @@
   }
 
   .local-navigation calcite-button {
-    padding-inline: var(--space-4);
     background-color: #2b2b2b;
+    padding-inline: var(--space-4);
   }
 
   .local-navigation calcite-icon {

--- a/eds/blocks/location-presence/location-presence.css
+++ b/eds/blocks/location-presence/location-presence.css
@@ -3,37 +3,37 @@
   --content-spacing: var(--space-2);
   --title-size: var(--font-4);
 
-  padding: var(--space-24) 0 var(--space-32);
+  align-items: center;
   background: var(--calcite-ui-foreground-1);
   color: var(--calcite-ui-text-1);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  padding: var(--space-24) 0 var(--space-32);
 }
 
 .location-content-container {
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
   inline-size: 1440px;
+  margin-inline: auto;
   max-inline-size: 96vw;
   padding-inline: 0;
-  margin-inline: auto;
   text-align: center;
 }
 
 .location-presence-heading {
   color: var(--calcite-ui-text-1);
   font-size: var(--title-size);
-  margin-block: 3rem 0.5rem;
   font-weight: var(--calcite-font-weight-normal);
+  margin-block: 3rem 0.5rem;
 }
 
 .location-presence-subtitle {
-  margin-block: 0 var(--space-2);
-  max-inline-size: 700px;
   color: var(--calcite-ui-text-2);
   font-size: var(--subtitle-size);
+  margin-block: 0 var(--space-2);
+  max-inline-size: 700px;
 }
 
 .location-presence-button {

--- a/eds/blocks/map/map.css
+++ b/eds/blocks/map/map.css
@@ -1,9 +1,14 @@
 
 .section.map-container {
+  background-attachment: var(--bg-img-attachment);
+  background-image: var(--bg-overlay), var(--bg-img);
+  background-position: var(--bg-img-position);
   background-position-x: center;
   background-position-y: center;
-  padding-block: 3rem;
+  background-repeat: var(--bg-img-repeat);
+  background-size: var(--bg-img-size);
   margin-block: 0;
+  padding-block: 3rem;
 
   --bg-gradient-dir: to right;
   --bg-gradient-start: var(--bg-color);
@@ -22,33 +27,27 @@
   --bg-overlay-end-color: var(--esri-ui-opacity00-inverse);
   --bg-overlay-transition: min(20vw, 50%);
   --bg-overlay: linear-gradient(var(--bg-overlay-dir), var(--bg-overlay-start-color), var(--bg-overlay-start-color) var(--bg-overlay-transition), var(--bg-overlay-end-color));
-
-  background-image: var(--bg-overlay), var(--bg-img);
-  background-repeat: var(--bg-img-repeat);
-  background-position: var(--bg-img-position);
-  background-attachment: var(--bg-img-attachment);
-  background-size: var(--bg-img-size);
 }
 
 .grid-container {
   inline-size: 1440px;
+  margin-inline: auto;
   max-inline-size: 96vw;
   padding-inline: 0;
-  margin-inline: auto;
 }
 
 #map-default-content-wrapper:not(.section) {
-  color: #fff;
   background-color: transparent;
+  color: #fff;
+  padding: 0;
   padding-inline: 0.5rem;
   text-align: center;
-  padding: 0;
 }
 
 #map-default-content-wrapper > h2 {
   font-weight: var(--calcite-font-weight-normal);
-  margin: 0 0 var(--space-4);
   line-height: 1.375;
+  margin: 0 0 var(--space-4);
 }
 
 .map.block:not(.section) {
@@ -57,16 +56,16 @@
 }
 
 .iframe-map-placeholder {
-  inline-size: 100%;
   block-size: 100%;
   display: block;
+  inline-size: 100%;
 }
 
 hr.separator {
+  background-color: #0079c1;
+  block-size: 2px;
   border-block-start: none;
   inline-size: 40px;
-  block-size: 2px;
-  background-color: #0079c1;
 }
 
 hr.center, .text-center hr {
@@ -74,16 +73,16 @@ hr.center, .text-center hr {
 }
 
 #map-default-content-wrapper > div > p {
-  font-weight: var(--calcite-font-weight-normal);
   font-size: var(--font-4);
-  margin: 0 0 var(--space-4);
+  font-weight: var(--calcite-font-weight-normal);
   line-height: 1.375;
+  margin: 0 0 var(--space-4);
 }
 
 #map-frame {
-  inline-size: 100%;
   block-size: 100vh;
   border: none;
+  inline-size: 100%;
 }
 
 #map-text-content {
@@ -91,16 +90,16 @@ hr.center, .text-center hr {
 }
 
 #frame-wrapper.is-fullscreen {
-  inset-block-start: 0;
-  inset-inline-start: 0;
-  margin: 0;
+  block-size: 100%;
 
   /* block-size: 100%; */
   inline-size: 100%;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  margin: 0;
   max-inline-size: 100vw;
-  block-size: 100%;
-  position: fixed;
   padding: 0;
+  position: fixed;
   z-index: 11110;
 }
 
@@ -114,8 +113,8 @@ hr.center, .text-center hr {
 
 @media (width > 480px) {
   #map-default-content-wrapper {
-    margin-inline: 8vw;
     inline-size: 1200px;
+    margin-inline: 8vw;
     max-inline-size: 80vw;
 
   }
@@ -128,15 +127,15 @@ hr.center, .text-center hr {
 
 @media (width > 860px) {
   #map-default-content-wrapper {
-    margin-inline: 20vw;
     inline-size: 840px;
+    margin-inline: 20vw;
     max-inline-size: 56vw;
 
   }
 
   #frame-wrapper {
-    margin-inline: 12vw;
     inline-size: 1080px;
+    margin-inline: 12vw;
     max-inline-size: 72vw;
   }
 
@@ -144,14 +143,14 @@ hr.center, .text-center hr {
 
 @media (width > 1500px) {
   #map-default-content-wrapper {
-    margin-inline: 299px;
     inline-size: 840px;
+    margin-inline: 299px;
     max-inline-size: 56vw;
   }
 
   #frame-wrapper {
-    margin-inline: 179px;
     inline-size: 1080px;
+    margin-inline: 179px;
     max-inline-size: 72vw;
   }
 

--- a/eds/blocks/media-gallery/media-gallery.css
+++ b/eds/blocks/media-gallery/media-gallery.css
@@ -1,183 +1,183 @@
 .media-gallery-wrapper {
-    inline-size: 100vw;
+  inline-size: 100vw;
 }
 
 .media-gallery {
-    ul {
-        list-style-type: none;
-        display: grid;
-        grid-gap: 1rem;
-        inline-size: calc(100vw - 4rem);
-        margin: auto;
-        padding: 0;
+  ul {
+    display: grid;
+    grid-gap: 1rem;
+    inline-size: calc(100vw - 4rem);
+    list-style-type: none;
+    margin: auto;
+    padding: 0;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  picture {
+    aspect-ratio: 16/9;
+    display: block;
+    overflow: hidden;
+    position: relative;
+  }
+
+  picture::after {
+    --gradient-angle: to top;
+    --gradient-angle-m: to top;
+    --gradient-transition: 60%;
+
+    background: linear-gradient(to top, var(--esri-ui-opacity80-inverse), transparent 60%);
+    block-size: 100%;
+    content: "";
+    inline-size: 100%;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    position: absolute;
+  }
+
+  .cards-card-body {
+    position: relative;
+  }
+
+  .card-content {
+    block-size: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    inline-size: 100%;
+    inset-block-start: 0;
+    justify-content: flex-end;
+    padding: 0 var(--space-6) var(--space-6) var(--space-6);
+    position: absolute;
+    z-index: 1;
+  }
+
+  .card-category {
+    background-color: var(--esri-ui-opacity85-inverse);
+    color: var(--calcite-ui-text-2);
+    font-size: var(--font-minus-2);
+    font-weight: var(--calcite-font-weight-bold);
+    inline-size: fit-content;
+    line-height: 1;
+    margin-block-end: var(--space-2);
+    margin-inline-start: -1.5rem;
+    padding: var(--space-2);
+    padding-inline-start: 1.5rem;
+    text-transform: uppercase;
+  }
+
+  .card-title {
+    color: white;
+    font-family: var(--calcite-sans-family);
+    font-size: var(--font-2);
+    font-weight: var(--calcite-font-weight-normal);
+    line-height: 1.2;
+    margin: 0;
+    pointer-events: none;
+    text-align: start;
+  }
+
+  .card-description {
+    -webkit-box-orient: vertical;
+    color: white;
+    display: none;
+    font-family: var(--calcite-sans-family);
+    font-size: clamp(.8rem, 1vw, 1rem);
+    font-weight: 400;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    line-height: 1.2;
+    margin-block-end: 0;
+    overflow: hidden;
+    pointer-events: none;
+    text-align: start;
+    text-overflow: ellipsis;
+  }
+
+  img {
+    aspect-ratio: 16/9;
+    inline-size: 100%;
+    object-fit: cover;
+  }
+
+  .card-content, img {
+    transition: 0.2s ease;
+  }
+
+  .cards-card-body:is(:hover,:focus,:focus-within) .card-content {
+    box-shadow: 0 0 0 10px inset var(--esri-ui-opacity80);
+  }
+
+  .cards-card-body:is(:hover,:focus,:focus-within) img {
+    transform: scale(1.08);
+  }
+
+  .start-button {
+    align-items: center;
+    block-size: 44px;
+    display: flex;
+    inline-size: 44px;
+    inset-block-start: calc(50% - 22px);
+    inset-inline-start: calc(50% - 22px);
+    justify-content: center;
+    margin: 0;
+    margin-block-end: 8px;
+    position: absolute;
+    z-index: 2;
+
+    svg {
+      block-size: 24px;
+      inline-size: 24px;
     }
-
-    p {
-        margin: 0;
-    }
-
-    picture {
-        display: block;
-        aspect-ratio: 16/9;
-        overflow: hidden;
-        position: relative;
-    }
-
-    picture::after {
-        --gradient-angle: to top;
-        --gradient-angle-m: to top;
-        --gradient-transition: 60%;
-
-        content: "";
-        block-size: 100%;
-        inline-size: 100%;
-        position: absolute;
-        inset-block-end: 0;
-        inset-inline-start: 0;
-        background: linear-gradient(to top, var(--esri-ui-opacity80-inverse), transparent 60%);
-    }
-
-    .cards-card-body {
-        position: relative;
-    }
-
-    .card-content {
-        position: absolute;
-        z-index: 1;
-        inset-block-start: 0;
-        inline-size: 100%;
-        block-size: 100%;
-        padding: 0 var(--space-6) var(--space-6) var(--space-6);
-        box-sizing: border-box;
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-end;
-    }
-
-    .card-category {
-        background-color: var(--esri-ui-opacity85-inverse);
-        color: var(--calcite-ui-text-2);
-        font-size: var(--font-minus-2);
-        font-weight: var(--calcite-font-weight-bold);
-        inline-size: fit-content;
-        line-height: 1;
-        margin-block-end: var(--space-2);
-        margin-inline-start: -1.5rem;
-        padding: var(--space-2);
-        padding-inline-start: 1.5rem;
-        text-transform: uppercase;
-    }
-
-    .card-title {
-        color: white;
-        font-family: var(--calcite-sans-family);
-        font-size: var(--font-2);
-        font-weight: var(--calcite-font-weight-normal);
-        line-height: 1.2;
-        margin: 0;
-        pointer-events: none;
-        text-align: start;
-    }
-
-    .card-description {
-        display: none;
-        pointer-events: none;
-        color: white;
-        font-weight: 400;
-        font-family: var(--calcite-sans-family);
-        text-align: start;
-        font-size: clamp(.8rem,1vw,1rem);
-        line-height: 1.2;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
-        line-clamp: 2;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        margin-block-end: 0;
-    }
-
-    img {
-        inline-size: 100%;
-        aspect-ratio: 16/9;
-        object-fit: cover;
-    }
-
-    .card-content, img {
-        transition: 0.2s ease;
-    }
-
-    .cards-card-body:is(:hover,:focus,:focus-within) .card-content {
-        box-shadow: 0 0 0 10px inset var(--esri-ui-opacity80);
-    }
-
-    .cards-card-body:is(:hover,:focus,:focus-within) img {
-        transform: scale(1.08);
-    }
-
-    .start-button {
-        margin: 0;
-        margin-block-end: 8px;
-        inline-size: 44px;
-        block-size: 44px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        position: absolute;
-        z-index: 2;
-        inset-block-start: calc(50% - 22px);
-        inset-inline-start: calc(50% - 22px);
-
-        svg {
-            inline-size: 24px;
-            block-size: 24px;
-        }
-    }
+  }
 }
 
 @media (width >= 768px) {
-    .media-gallery {
-        ul {
-            grid-template-columns: 1fr 1fr;
-        }
-
-        .card-title {
-            margin-block-end: 0.5rem;
-        }
-
-        .card-description {
-            display: -webkit-box;
-        }
-
-        .start-button {
-            position: static;
-        }
+  .media-gallery {
+    ul {
+      grid-template-columns: 1fr 1fr;
     }
+
+    .card-title {
+      margin-block-end: 0.5rem;
+    }
+
+    .card-description {
+      display: -webkit-box;
+    }
+
+    .start-button {
+      position: static;
+    }
+  }
 }
 
 @media (width >= 1152px) {
-    .media-gallery {
-        ul {
-            grid-template-columns: 1fr 1fr 1fr;
-            grid-template-rows: 1fr 1fr;
-            inline-size: 90%;
-        }
+  .media-gallery {
+    ul {
+      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      inline-size: 90%;
+    }
+  }
+
+  .media-gallery.alternate-2-1 {
+    .grid-item-0, .grid-item-3 {
+      img, picture {
+        aspect-ratio: 1296/360;
+      }
     }
 
-    .media-gallery.alternate-2-1 {
-        .grid-item-0, .grid-item-3 {
-            img, picture {
-                aspect-ratio:  1296/360;
-            }
-        }
-
-        .grid-item-0 {
-            grid-column: 1/3;
-            grid-row: 1;
-        }
-
-        .grid-item-3 {
-            grid-column: 2/4;
-            grid-row: 2;
-        }
+    .grid-item-0 {
+      grid-column: 1/3;
+      grid-row: 1;
     }
+
+    .grid-item-3 {
+      grid-column: 2/4;
+      grid-row: 2;
+    }
+  }
 }

--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -1,21 +1,21 @@
 .mosaic-reveal-container {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
 }
 
 .mosaic-reveal-container h2 {
   font-size: calc(100% + 6vw);
-  line-height: 1.1;
-  font-weight: var(--calcite-font-weight-medium);
   font-style: normal;
+  font-weight: var(--calcite-font-weight-medium);
+  line-height: 1.1;
   margin: 0 0 var(--space-4);
 }
 
 .mosaic-reveal-container > div:first-child {
-  padding: var(--space-8) 11%;
   box-sizing: border-box;
+  padding: var(--space-8) 11%;
 }
 
 .mosaic-reveal {
@@ -23,36 +23,36 @@
   --calcite-ui-text-link: var(--calcite-ui-text-1);
   --calcite-link-blue-underline: #fff6;
 
-  overflow: hidden;
-  position: relative;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
+  overflow: hidden;
+  position: relative;
 
 }
-  
+
 .mosaic-reveal calcite-icon {
-  position: absolute;
   inset-block-end: var(--space-4);
   inset-inline-end: var(--space-4);
+  position: absolute;
   z-index: 2;
 }
 
 .mosaic-reveal .mosaic-reveal-content {
-  position: absolute;
-  inline-size: 100%;
-  block-size: 100%;
-  inset-inline-start: 0;
-  background-color: var(--calcite-ui-foreground-1);
-  z-index: 5;
-  display: flex;
   align-items: center;
-  justify-content: center;
+  background-color: var(--calcite-ui-foreground-1);
+  block-size: 100%;
+  display: flex;
   flex-direction: column;
-  transition: 0.5s ease;
+  inline-size: 100%;
   inset-block-start: 0;
-  transform-origin: 50% 100%;
+  inset-inline-start: 0;
+  justify-content: center;
   opacity: 1;
+  position: absolute;
+  transform-origin: 50% 100%;
+  transition: 0.5s ease;
+  z-index: 5;
 }
 
 .mosaic-reveal .mosaic-reveal-content > :is(h3, p, p > a, .button-container) {
@@ -61,14 +61,14 @@
 
 .mosaic-reveal .mosaic-reveal-content > h3 {
   font-size: 1.414rem;
-  margin: 0 0 var(--space-4) 0;
   line-height: 1.375;
+  margin: 0 0 var(--space-4) 0;
 }
 
 .mosaic-reveal .mosaic-reveal-content > p:nth-child(3) {
-  margin-block-end: var(--space-4);
-  line-height: 1.25;
   font-size: var(--font-minus-1);
+  line-height: 1.25;
+  margin-block-end: var(--space-4);
 }
 
 .mosaic-reveal .mosaic-reveal-content > p.button-container {
@@ -80,26 +80,26 @@
   text-decoration: underline;
 }
 
-.mosaic-reveal .mosaic-reveal-content[aria-hidden='true'] {
+.mosaic-reveal .mosaic-reveal-content[aria-hidden="true"] {
   inset-block-start: 100%;
   opacity: 0;
   pointer-events: none;
 }
 
 .mosaic-reveal > div { /* stylelint-disable-line no-descending-specificity */
-  position: relative;
   overflow: hidden;
+  position: relative;
 }
 
 .mosaic-reveal > div::after {
-  position: absolute;
-  inset-inline-start: 0;
-  inset-block-start: 0;
-  inline-size: 100%;
+  background: linear-gradient(to bottom, #0000 66%, #000000b3 100%);
+  block-size: 100%;
   content: "";
   display: block;
-  block-size: 100%;
-  background: linear-gradient(to bottom, #0000 66%, #000000b3 100%);
+  inline-size: 100%;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  position: absolute;
 }
 
 .mosaic-reveal > div:last-child::after {
@@ -107,9 +107,9 @@
 }
 
 .mosaic-reveal picture {
-  display: block;
   block-size: calc(220px + 50vw - 180px);
   cursor: pointer;
+  display: block;
   overflow: hidden;
 }
 
@@ -119,17 +119,17 @@
 }
 
 .mosaic-reveal .title {
-  position: absolute;
-  inset-block-end: 0;
-  z-index: 2;
-  padding: var(--space-1) var(--space-12) var(--space-4) var(--space-5);
-  margin: 0;
-  font-size: 1.2rem;
-  color: var(--calcite-ui-text-1);
-  font-weight: var(--calcite-font-weight-normal);
-  line-height: 1.375;
-  inline-size: 100%;
   box-sizing: border-box;
+  color: var(--calcite-ui-text-1);
+  font-size: 1.2rem;
+  font-weight: var(--calcite-font-weight-normal);
+  inline-size: 100%;
+  inset-block-end: 0;
+  line-height: 1.375;
+  margin: 0;
+  padding: var(--space-1) var(--space-12) var(--space-4) var(--space-5);
+  position: absolute;
+  z-index: 2;
 }
 
 @media (width >= 480px) {
@@ -184,8 +184,8 @@
   }
 
   .mosaic-reveal .title {
-    padding: var(--space-4) var(--space-6) var(--space-12);
     font-size: 1.414rem;
+    padding: var(--space-4) var(--space-6) var(--space-12);
   }
 }
 

--- a/eds/blocks/sidedrawer/sidedrawer.css
+++ b/eds/blocks/sidedrawer/sidedrawer.css
@@ -1,89 +1,89 @@
 .section.sidedrawer-container {
-    float: unset;
-    inline-size: unset;
-    clear: unset;
-    padding: 0;
-    inset-block-start: 150px;
-    position: relative
+  clear: unset;
+  float: unset;
+  inline-size: unset;
+  inset-block-start: 150px;
+  padding: 0;
+  position: relative
 }
 
 .sidedrawer {
-    display: none;
+  display: none;
 }
 
 .sidedrawer-button {
-    position: absolute;
-    font-weight: var(--calcite-font-weight-medium);
-    cursor: pointer;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    writing-mode: vertical-rl;
-    padding: calc(var(--space-3) + 4px);
-    background-color: var(--calcite-ui-border-2);
-    white-space: nowrap;
-    color: var(--calcite-ui-text-1);
-    padding-inline: calc(var(--space-12) - 3px) var(--space-6);
-    border-color: var(--calcite-ui-border-2);
-    margin-block-end: -50px;
+  background-color: var(--calcite-ui-border-2);
+  border-color: var(--calcite-ui-border-2);
+  color: var(--calcite-ui-text-1);
+  cursor: pointer;
+  font-weight: var(--calcite-font-weight-medium);
+  letter-spacing: 2px;
+  margin-block-end: -50px;
+  padding: calc(var(--space-3) + 4px);
+  padding-inline: calc(var(--space-12) - 3px) var(--space-6);
+  position: absolute;
+  text-transform: uppercase;
+  white-space: nowrap;
+  writing-mode: vertical-rl;
 }
 
 .sidedrawer-button:is(:hover, :focus) {
-    background-color: var(--calcite-ui-border-2);
+  background-color: var(--calcite-ui-border-2);
 }
 
 html[dir="rtl"] .sidedrawer-button {
-    margin-block: -50px auto;
-    padding-inline: var(--space-6) calc(var(--space-12) + 5px);
-    margin-inline-end: 0;
+  margin-block: -50px auto;
+  margin-inline-end: 0;
+  padding-inline: var(--space-6) calc(var(--space-12) + 5px);
 }
 
 .sidedrawer-wrapper .sidedrawer.block {
-    transition: all 0.6s ease-out;
+  transition: all 0.6s ease-out;
 }
 
 .sidedrawer-wrapper .sidedrawer-content-wrapper {
-    background: var(--calcite-ui-foreground-1);
-    transform-origin: top left;
-    border: 0;
+  background: var(--calcite-ui-foreground-1);
+  border: 0;
+  transform-origin: top left;
 }
 
 .sidedrawer-content {
-    border: 0;
+  border: 0;
 }
 
 .sidedrawer-contentframe {
-    padding: 54px;
-    inline-size: 550px;
-    max-inline-size: 95vw;
-    block-size: 90.25vw;
-    max-block-size: 300px;
-    min-block-size: 0;
-    color: var(--calcite-ui-text-1);
-    background-color: var(--calcite-ui-foreground-1);
+  background-color: var(--calcite-ui-foreground-1);
+  block-size: 90.25vw;
+  color: var(--calcite-ui-text-1);
+  inline-size: 550px;
+  max-block-size: 300px;
+  max-inline-size: 95vw;
+  min-block-size: 0;
+  padding: 54px;
 }
 
 @media (width >= 1024px) {
-    .block.sidedrawer {
-        display: block;
-        position: fixed;
-        inset-inline-end: -2px;
-        z-index: 999;
-        margin-inline: 99% 0;
-        padding: 0;
-   }
+  .block.sidedrawer {
+    display: block;
+    inset-inline-end: -2px;
+    margin-inline: 99% 0;
+    padding: 0;
+    position: fixed;
+    z-index: 999;
+  }
 
-    .sidedrawer-content[aria-expanded="false"] {
-        max-inline-size: 0;
-        transition: all 0.6s ease-out;
-   }
+  .sidedrawer-content[aria-expanded="false"] {
+    max-inline-size: 0;
+    transition: all 0.6s ease-out;
+  }
 
-    .sidedrawer-content[aria-expanded="true"]{
-        transition: all 0.6s ease-out;
-        inline-size: 100%;
-        max-inline-size: 700px;
-   }
+  .sidedrawer-content[aria-expanded="true"] {
+    inline-size: 100%;
+    max-inline-size: 700px;
+    transition: all 0.6s ease-out;
+  }
 
-    html[dir="rtl"] .sidedrawer {
-        inset-inline: auto -2px;
-    }
+  html[dir="rtl"] .sidedrawer {
+    inset-inline: auto -2px;
+  }
 }

--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -22,12 +22,12 @@
 }
 
 .storyteller .foreground-content .content-wrapper, .storyteller.primary-content .foreground-content .content-wrapper {
-  opacity: 0.85;
   align-self: end;
-  inline-size: 450px;
-  position: absolute;
-  color: var(--calcite-ui-text-1);
   background-color: var(--calcite-ui-background);
+  color: var(--calcite-ui-text-1);
+  inline-size: 450px;
+  opacity: 0.85;
+  position: absolute;
 }
 
 .storyteller.primary-content h2, .storyteller.primary-content p:nth-of-type(1), .storyteller.storyteller.primary-content p.button-container {
@@ -50,7 +50,7 @@
   padding-inline-end: var(--space-12);
 }
 
-.storyteller.primary-content div:nth-of-type(2) p { 
+.storyteller.primary-content div:nth-of-type(2) p {
   inline-size: 90%;
 }
 
@@ -67,13 +67,13 @@
 }
 
 .storyteller div div:nth-of-type(2) p:nth-of-type(1) picture img {
-  max-inline-size: 100%;
   block-size: 100%;
+  max-inline-size: 100%;
 }
 
 .storyteller div div:nth-of-type(2) p:nth-of-type(1) picture img, .storyteller.primary-content div:nth-of-type(1) p:nth-of-type(1) picture img {
-  object-fit: cover;
   aspect-ratio: 1 / 1;
+  object-fit: cover;
 }
 
 .storyteller.primary-content div:nth-of-type(1) p:nth-of-type(1) picture img {
@@ -90,19 +90,19 @@
 }
 
 .storyteller .foreground-content {
-  display: flex;
   block-size: 100%;
+  display: flex;
   position: relative;
 }
 
 .storyteller div div .foreground-container picture {
   display: block;
-  position: absolute 
+  position: absolute
 }
 
 .storyteller:not(.primary-content) div:nth-of-type(1) div:nth-of-type(2) p:nth-of-type(2), .storyteller div div p:nth-of-type(2).foreground-container, .storyteller.primary-content div div p:nth-of-type(2).foreground-container {
-  margin-inline: var(--space-6);
-  margin-block-start: var(--space-8)
+  margin-block-start: var(--space-8);
+  margin-inline: var(--space-6)
 }
 
 .storyteller.primary-content div div:nth-of-type(1).button-container {
@@ -111,7 +111,7 @@
 
 .storyteller.primary-content div div:nth-of-type(2).button-container {
   padding-inline: 0;
-} 
+}
 
 .storyteller.primary-content .foreground-content, .storyteller.primary-content div div p:nth-of-type(2).foreground-container {
   padding-inline: 0;
@@ -123,20 +123,20 @@
 
 .storyteller div div:nth-of-type(2) p:nth-of-type(1) picture {
   block-size: 100%;
-  position: absolute;
   padding-inline-start: var(--space-24);
+  position: absolute;
 }
 
 .storyteller.primary-content div div p:nth-of-type(2) picture {
-  inset-block-start: 50%;
-  transform: translateY(-50%);
-  position: absolute;
-  inset-inline-end: 0;
   inline-size: 500px;
+  inset-block-start: 50%;
+  inset-inline-end: 0;
   margin: 0 auto;
   padding: 0;
+  position: absolute;
+  transform: translateY(-50%);
 }
- 
+
 .storyteller div p:nth-of-type(2) video {
   inline-size: 100%;
   position: relative;
@@ -152,8 +152,8 @@
 
 .storyteller div:nth-of-type(1) div:nth-of-type(1) .icon-wrapper .storyteller-row {
   display: flex;
-  inline-size: 100%;
   flex-direction: row;
+  inline-size: 100%;
   padding-inline: 0;
 }
 
@@ -171,8 +171,8 @@
 }
 
 .storyteller .icon-wrapper .storyteller-row picture.icon-picture img {
-  max-inline-size: max-content;
   block-size: auto;
+  max-inline-size: max-content;
 }
 
 .storyteller div:nth-of-type(1) div:nth-of-type(1) .icon-wrapper .storyteller-row .icon-title {
@@ -184,13 +184,13 @@
 }
 
 .storyteller .play-progress-circle {
-  opacity: 1;
-  stroke: var(--calcite-ui-foreground-1);
-  inline-size: 8px;
   block-size: 35px;
-  stroke-width: 6px;
+  inline-size: 8px;
+  opacity: 1;
   position: relative;
+  stroke: var(--calcite-ui-foreground-1);
   stroke-linecap: round;
+  stroke-width: 6px;
   transform: rotate(-90deg);
 }
 
@@ -200,14 +200,14 @@
 }
 
 .storyteller .foreground-container .video-container .video-playbutton {
-  border: 1px solid #fff;
-  display: flex;
-  cursor: pointer;
-  padding: 0 14px;
-  border-radius: 50%;
   align-items: center;
-  justify-content: center;
   background-color: transparent;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  padding: 0 14px;
 }
 
 .storyteller .foreground-container .video-container .video-playbutton.paused::after {
@@ -215,33 +215,33 @@
 }
 
 .storyteller .foreground-container .video-container .video-playbutton::after {
-  content: '';
-  position: absolute;
-  inline-size: 20px;
-  block-size: 20px;
-  display: inline-block;
-  background-size: 20px 20px;
   background-color: #fff;
-  mask: url('data:image/svg+xml;base64,PHN2ZyBpZD0iRXhwb3J0YWJsZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjAgMjAiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMWQxZDFmfTwvc3R5bGU+PC9kZWZzPjxnIGlkPSJwYXVzZSI+PHJlY3QgY2xhc3M9ImNscy0xIiB4PSIzLjc1IiB5PSIzIiB3aWR0aD0iNC41IiBoZWlnaHQ9IjE0IiByeD0iMS41Ii8+PHJlY3QgY2xhc3M9ImNscy0xIiB4PSIxMS43NSIgeT0iMyIgd2lkdGg9IjQuNSIgaGVpZ2h0PSIxNCIgcng9IjEuNSIvPjwvZz48L3N2Zz4=');
+  background-size: 20px 20px;
+  block-size: 20px;
+  content: "";
+  display: inline-block;
+  inline-size: 20px;
+  mask: url("data:image/svg+xml;base64,PHN2ZyBpZD0iRXhwb3J0YWJsZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjAgMjAiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMWQxZDFmfTwvc3R5bGU+PC9kZWZzPjxnIGlkPSJwYXVzZSI+PHJlY3QgY2xhc3M9ImNscy0xIiB4PSIzLjc1IiB5PSIzIiB3aWR0aD0iNC41IiBoZWlnaHQ9IjE0IiByeD0iMS41Ii8+PHJlY3QgY2xhc3M9ImNscy0xIiB4PSIxMS43NSIgeT0iMyIgd2lkdGg9IjQuNSIgaGVpZ2h0PSIxNCIgcng9IjEuNSIvPjwvZz48L3N2Zz4=");
+  position: absolute;
 }
 
 .storyteller div div p.foreground-container .video-container {
-    position: absolute;
-    z-index: 2;
-    padding: 0;
-    cursor: pointer;
-    pointer-events: auto;
-    inset-inline-end: 0;
-    inset-block-start: 0;
-    inline-size: 60px;
+  cursor: pointer;
+  inline-size: 60px;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  padding: 0;
+  pointer-events: auto;
+  position: absolute;
+  z-index: 2;
 }
 
 @media (width >= 510px) {
   .storyteller div div:nth-of-type(2) .foreground-content, .storyteller div p:nth-of-type(2) video, .storyteller .foreground-container, .storyteller div div:nth-of-type(2) p:nth-of-type(2) picture img {
-    inline-size: 500px;
     block-size: 625px;
+    inline-size: 500px;
   }
-  
+
   .storyteller.primary-content .foreground-container {
     margin-inline-start: var(--space-6);
   }
@@ -253,12 +253,12 @@
   }
 }
 
-@media (width >= 1152px) { 
+@media (width >= 1152px) {
   .storyteller {
-    padding: 0 ;
     inline-size: 100%;
-    position: relative;
     min-block-size: 1100px;
+    padding: 0;
+    position: relative;
   }
 
   .storyteller div div .foreground-container picture {
@@ -266,20 +266,20 @@
   }
 
   .storyteller div:nth-of-type(1) div:nth-of-type(1) div.icon-wrapper {
-  inline-size: 100%;
-  padding-inline-start: var(--space-32);
-  margin-block-start: var(--space-4);
-  max-inline-size: 660px;
-  margin-inline-start: auto;
-}
+    inline-size: 100%;
+    margin-block-start: var(--space-4);
+    margin-inline-start: auto;
+    max-inline-size: 660px;
+    padding-inline-start: var(--space-32);
+  }
 
   .section > div.storyteller-wrapper, .storyteller .foreground-content .content-wrapper h2 {
     margin-block-end: 0;
   }
 
   .storyteller.primary-content div div:nth-of-type(2) > h2 {
-    max-inline-size: 600px;
     margin-inline-end: var(--space-20);
+    max-inline-size: 600px;
   }
 
   .storyteller div div p:not(.button-container) {
@@ -288,7 +288,7 @@
 
   .storyteller .foreground-content, .storyteller p picture, .storyteller div:nth-of-type(2) .content-wrapper p {
     padding-inline-start: 0;
-  } 
+  }
 
   .storyteller.primary-content div:nth-of-type(2) p {
     inline-size: 75%;
@@ -298,7 +298,7 @@
   .storyteller.primary-content div .foreground-content .content-wrapper p {
     padding-inline: var(--space-4);
   }
-  
+
   .storyteller:not(.primary-content) div:nth-of-type(1) div:nth-child(1) h2, .storyteller:not(.primary-content) div:nth-of-type(1) div:nth-of-type(1) .button-container, .storyteller:not(.primary-content) div:nth-of-type(1) div:nth-child(1) p {
     margin-inline-start: auto;
     max-inline-size: 660px;
@@ -321,65 +321,65 @@
   }
 
   .storyteller:not(.primary-content) div:nth-of-type(1) div:nth-of-type(2) p:nth-of-type(2), .storyteller.primary-content div div p:nth-of-type(2).foreground-container {
-    margin-inline: var(--space-6);
     margin-block-start: 0;
+    margin-inline: var(--space-6);
   }
 
   .storyteller > div {
-    display: flex;
-    block-size: 100%;
-    inline-size: 100%;
     align-items: center;
+    block-size: 100%;
+    display: flex;
     flex-direction: row;
+    inline-size: 100%;
   }
 
   .storyteller.primary-content div {
     flex-direction: row;
   }
-    
+
   .storyteller div div:nth-of-type(2) {
     block-size: 100%;
   }
 
   .storyteller .foreground-container {
-    position: absolute;
-    overflow: hidden;
     inset-block: 50% 0;
+    overflow: hidden;
+    position: absolute;
     transform: translateY(-50%);
   }
 
   .storyteller div div:nth-of-type(1), .storyteller div div:nth-of-type(2), .storyteller.primary-content .foreground-container {
     inline-size: 50%;
   }
-  
+
   .storyteller.primary-content div div:nth-of-type(1) {
     position: relative;
   }
 
   .storyteller.primary-content div div:nth-of-type(2) {
-    display: block;
     block-size: auto;
+    display: block;
     inline-size: 50%;
-    padding: var(--space-20) 0 var(--space-20) var(--space-16) ;
+    padding: var(--space-20) 0 var(--space-20) var(--space-16);
   }
 
   .storyteller.primary-content div div:nth-of-type(2) .button-container {
-    padding: var(--space-2) 0 var(--space-2) 0 ;
     cursor: pointer;
+    padding: var(--space-2) 0 var(--space-2) 0;
   }
 
   .storyteller .foreground-content .content-wrapper, .storyteller:not(.primary-content) div:nth-of-type(1) div:nth-of-type(1), .storyteller:not(.primary-content) div div:nth-of-type(2) .foreground-container .foreground-content h2, .storyteller:not(.primary-content) div div:nth-of-type(2) p.foreground-container .foreground-content p {
     padding-inline: 0;
   }
 
-  .storyteller:not(.primary-content) div div:nth-of-type(2) .foreground-container .foreground-content  .content-wrapper > * {
+  .storyteller:not(.primary-content) div div:nth-of-type(2) .foreground-container .foreground-content .content-wrapper > * {
     padding-inline: var(--space-4);
   }
 
   .storyteller div p:nth-of-type(2) video, .storyteller.primary-content div p:nth-of-type(2) video, .storyteller .foreground-content .content-wrapper, .storyteller.primary-content .foreground-content .content-wrapper {
     position: absolute;
   }
-  
+
   .storyteller button.video-playbutton {
     /* margin-inline-end: var(--space-4);  */
   }
@@ -393,22 +393,22 @@
   }
 
   .storyteller div div:nth-of-type(2) p:nth-of-type(2) picture, .storyteller.primary-content div div:nth-of-type(1) p:nth-of-type(2):not(.foreground-container) picture {
-    position: absolute;
     inset-block-start: 50%;
+    position: absolute;
     transform: translateY(-50%);
   }
 
   .storyteller.primary-content .foreground-container {
-    position: absolute;
-    overflow: visible clip;
     inset-inline: 50% 0;
+    overflow: visible clip;
+    position: absolute;
   }
 
   .storyteller.primary-content .foreground-content {
-    display: flex;
     block-size: 100%;
+    display: flex;
     inline-size: 100%;
-    position: relative;
     justify-content: end;
+    position: relative;
   }
 }

--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -55,7 +55,7 @@
     padding: 0 5vw;
     padding-block-start: 4rem;
 
-p, h2 {
+    p, h2 {
       inline-size: 90%;
     }
 
@@ -159,7 +159,7 @@ p, h2 {
       inset-inline-end: 0;
     }
 
-    .arrow-button[aria-hidden='true'] {
+    .arrow-button[aria-hidden="true"] {
       display: none;
     }
 
@@ -182,16 +182,16 @@ p, h2 {
       margin-block-end: 10px;
     }
 
-    .tab-title[aria-hidden='true'] {
+    .tab-title[aria-hidden="true"] {
       display: none;
     }
 
-    .tab-title[aria-hidden='false'] {
+    .tab-title[aria-hidden="false"] {
       border-block-end: 3px solid var(--calcite-ui-brand);
       padding-block-end: 0;
     }
 
-    .tab-title[aria-selected='true'] .icon {
+    .tab-title[aria-selected="true"] .icon {
       --image-icon-filter: var(--image-icon-filter-brand);
     }
 
@@ -204,7 +204,7 @@ p, h2 {
     position: relative;
   }
 
-  .tab-content[aria-hidden='true'] {
+  .tab-content[aria-hidden="true"] {
     display: none;
   }
 
@@ -226,7 +226,7 @@ p, h2 {
       margin-inline-end: 0.7rem;
       padding-block-end: 0.75rem;
 
-    span {
+      span {
         color: var(--calcite-ui-text-1);
       }
     }
@@ -262,8 +262,8 @@ p, h2 {
     }
 
     .tab-component {
-        position: relative;
-      }
+      position: relative;
+    }
 
     .tab-nav {
       box-sizing: content-box;
@@ -286,23 +286,23 @@ p, h2 {
         padding: 1rem;
       }
 
-      .tab-title[aria-hidden='false'] {
+      .tab-title[aria-hidden="false"] {
         border-block-end: 3px solid transparent;
       }
 
-      .tab-title[aria-selected='false']:hover {
+      .tab-title[aria-selected="false"]:hover {
         border-block-end: 3px solid #0079c180;
       }
 
-      .tab-title[aria-selected='true'] {
+      .tab-title[aria-selected="true"] {
         border-block-end: 3px solid var(--calcite-ui-brand);
       }
     }
 
-    .tab-content[aria-hidden='false'] {
+    .tab-content[aria-hidden="false"] {
       & > .grid-container {
         display: grid;
-        grid-template: 
+        grid-template:
         "text img"
         "buttons img"
         auto / 1fr 1fr;
@@ -326,21 +326,21 @@ p, h2 {
       }
     }
 
-    .tab-content[aria-hidden='false'] p:last-child {
+    .tab-content[aria-hidden="false"] p:last-child {
       grid-area: img;
     }
 
-    .tab-content[aria-hidden='false'] p:last-child picture {
+    .tab-content[aria-hidden="false"] p:last-child picture {
       inline-size: 100%;
     }
 
-    .tab-content[aria-hidden='false'] p:last-child picture img {
+    .tab-content[aria-hidden="false"] p:last-child picture img {
       block-size: 100%;
       object-fit: cover;
       object-position: center;
     }
 
-    .tab-content[aria-hidden='false'] > .grid-container > p:first-child {
+    .tab-content[aria-hidden="false"] > .grid-container > p:first-child {
       block-size: 100%;
       inline-size: 100%;
       inset-block-start: 0;
@@ -372,7 +372,7 @@ p, h2 {
 }
 
 @media (width >= 1480px) {
-  .tabs .tab-content[aria-hidden='false'] :is(.text-wrapper, .buttons-wrapper) {
+  .tabs .tab-content[aria-hidden="false"] :is(.text-wrapper, .buttons-wrapper) {
     inline-size: 720px;
     margin-inline: auto 0;
     padding-inline-start: 0;

--- a/eds/blocks/text/text.css
+++ b/eds/blocks/text/text.css
@@ -1,156 +1,156 @@
 .esritext-body {
-    --category-size: var(--font-minus-2);
-    --title-size: var(--font-4);
-    --subtitle-size: var(--font-2);
-    --description-size: var(--font-0);
-    --content-spacing: var(--space-2);
-    --content-end-spacing: var(--space-6);
+  --category-size: var(--font-minus-2);
+  --title-size: var(--font-4);
+  --subtitle-size: var(--font-2);
+  --description-size: var(--font-0);
+  --content-spacing: var(--space-2);
+  --content-end-spacing: var(--space-6);
 }
 
 /* Modifies text code based on sizes */
 
-:where(.size-7, .size-6, .size-5) .esritext-body{
-    --content-spacing: var(--space-2);
-    --content-end-spacing: var(--space-8);
+:where(.size-7, .size-6, .size-5) .esritext-body {
+  --content-spacing: var(--space-2);
+  --content-end-spacing: var(--space-8);
 }
 
-:where(.size-2, .size-1, .size-0) .esritext-body{
-    --content-spacing: var(--space-2);
-    --content-end-spacing: var(--space-5);
+:where(.size-2, .size-1, .size-0) .esritext-body {
+  --content-spacing: var(--space-2);
+  --content-end-spacing: var(--space-5);
 }
 
-:where(.size-4, .size-3) .esritext-body{
-    --content-spacing: var(--space-2);
-    --content-end-spacing: var(--space-6);
+:where(.size-4, .size-3) .esritext-body {
+  --content-spacing: var(--space-2);
+  --content-end-spacing: var(--space-6);
 }
 
 .size-8 .esritext-body {
-    --category-size: var(--font-0);
-    --title-size: var(--font-8);
-    --subtitle-size: var(--font-4);
-    --description-size: var(--font-2);
-    --content-spacing: var(--space-3);
-    --content-end-spacing: var(--space-10);
+  --category-size: var(--font-0);
+  --title-size: var(--font-8);
+  --subtitle-size: var(--font-4);
+  --description-size: var(--font-2);
+  --content-spacing: var(--space-3);
+  --content-end-spacing: var(--space-10);
 }
 
 .size-7 .esritext-body {
-    --category-size: var(--font-minus-1);
-    --title-size: var(--font-7);
-    --subtitle-size: var(--font-4);
-    --description-size: var(--font-2);
+  --category-size: var(--font-minus-1);
+  --title-size: var(--font-7);
+  --subtitle-size: var(--font-4);
+  --description-size: var(--font-2);
 }
 
 .size-6 .esritext-body {
-    --category-size: var(--font-minus-1);
-    --title-size: var(--font-6);
-    --subtitle-size: var(--font-3);
-    --description-size: var(--font-2);
+  --category-size: var(--font-minus-1);
+  --title-size: var(--font-6);
+  --subtitle-size: var(--font-3);
+  --description-size: var(--font-2);
 }
 
 .size-5 .esritext-body {
-    --category-size: var(--font-minus-1);
-    --title-size: var(--font-5);
-    --subtitle-size: var(--font-3);
-    --description-size: var(--font-1);
+  --category-size: var(--font-minus-1);
+  --title-size: var(--font-5);
+  --subtitle-size: var(--font-3);
+  --description-size: var(--font-1);
 }
 
 .size-4 .esritext-body {
-    --category-size: var(--font-minus-2);
-    --title-size: var(--font-4);
-    --subtitle-size: var(--font-2);
-    --description-size: var(--font-0);
+  --category-size: var(--font-minus-2);
+  --title-size: var(--font-4);
+  --subtitle-size: var(--font-2);
+  --description-size: var(--font-0);
 }
 
 .size-3 .esritext-body {
-    --category-size: var(--font-minus-2);
-    --title-size: var(--font-3);
-    --subtitle-size: var(--font-1);
-    --description-size: var(--font-0);
+  --category-size: var(--font-minus-2);
+  --title-size: var(--font-3);
+  --subtitle-size: var(--font-1);
+  --description-size: var(--font-0);
 }
 
 .size-2 .esritext-body {
-    --category-size: var(--font-minus-2);
-    --title-size: var(--font-2);
-    --subtitle-size: var(--font-minus-1);
-    --description-size: var(--font-minus-1);
+  --category-size: var(--font-minus-2);
+  --title-size: var(--font-2);
+  --subtitle-size: var(--font-minus-1);
+  --description-size: var(--font-minus-1);
 }
 
 .size-1 .esritext-body {
-    --category-size: var(--font-minus-2);
-    --title-size: var(--font-1);
-    --subtitle-size: var(--font-minus-1);
-    --description-size: var(--font-minus-1);
+  --category-size: var(--font-minus-2);
+  --title-size: var(--font-1);
+  --subtitle-size: var(--font-minus-1);
+  --description-size: var(--font-minus-1);
 }
 
 .size-0 .esritext-body {
-    --category-size: var(--font-minus-3);
-    --title-size: var(--font-0);
-    --subtitle-size: var(--font-minus-2);
-    --description-size: var(--font-minus-1);
+  --category-size: var(--font-minus-3);
+  --title-size: var(--font-0);
+  --subtitle-size: var(--font-minus-2);
+  --description-size: var(--font-minus-1);
 }
 
 /* Icon size */
 :where(.size-6, .size-7, .size-8) .esritext-image :is(img, svg) {
-    inline-size: 64px;
-    block-size: 64px;
+  block-size: 64px;
+  inline-size: 64px;
 }
 
 .block.esri-text {
-    text-align: center;
+  text-align: center;
 
-    ul {
-        list-style-type: none;
-        padding: 0;
-        margin: 0 auto;
+  ul {
+    list-style-type: none;
+    margin: 0 auto;
+    padding: 0;
 
-        li {
-            max-inline-size: 80ch;
-            word-break: break-word;
-            margin-block-end: var(--content-spacing);
-            margin-inline: auto;
-        }
+    li {
+      margin-block-end: var(--content-spacing);
+      margin-inline: auto;
+      max-inline-size: 80ch;
+      word-break: break-word;
+    }
+  }
+
+  .esritext-image {
+    img {
+      block-size: 48px;
+      inline-size: 48px;
+    }
+  }
+
+  .esritext-body {
+    p {
+      color: var(--calcite-ui-text-1);
+      font-size: var(--description-size);
+      margin-block-end: var(--content-end-spacing);
     }
 
-    .esritext-image {
-        img {
-            block-size: 48px;
-            inline-size: 48px;
-        }
+    p:nth-child(1) {
+      color: var(--calcite-ui-text-2);
+      font-size: var(--category-size);
+      font-weight: var(--calcite-font-weight-bold);
+      margin-block-end: var(--content-spacing);
+      text-transform: uppercase;
     }
 
-    .esritext-body {
-        p {
-            color: var(--calcite-ui-text-1);
-            font-size: var(--description-size);
-            margin-block-end: var(--content-end-spacing);
-        }
-
-        p:nth-child(1) {
-            font-weight: var(--calcite-font-weight-bold);
-            text-transform: uppercase;
-            color: var(--calcite-ui-text-2);
-            font-size: var(--category-size);
-            margin-block-end: var(--content-spacing);
-        }
-
-        h3 {
-            color: var(--calcite-ui-text-1);
-            font-size: var(--title-size);
-            margin-block-end: var(--content-spacing);
-        }
-
-        h4 {
-            color: var(--calcite-ui-text-2);
-            font-size: var(--subtitle-size);
-            margin-block-end: var(--content-spacing); 
-        }
+    h3 {
+      color: var(--calcite-ui-text-1);
+      font-size: var(--title-size);
+      margin-block-end: var(--content-spacing);
     }
 
-    &.leftaligned{
-        text-align: start;
-
-        li{
-            margin-inline: 0;
-        }
+    h4 {
+      color: var(--calcite-ui-text-2);
+      font-size: var(--subtitle-size);
+      margin-block-end: var(--content-spacing);
     }
+  }
+
+  &.leftaligned {
+    text-align: start;
+
+    li {
+      margin-inline: 0;
+    }
+  }
 }

--- a/eds/blocks/video-cards/video-cards.css
+++ b/eds/blocks/video-cards/video-cards.css
@@ -1,11 +1,11 @@
 .video-cards {
-  inline-size: 1440px;
-  max-inline-size: 92vw;
+  background-color: var(--calcite-ui-foreground-1);
   display: flex;
   flex-direction: column;
+  inline-size: 1440px;
   margin: 0 auto;
+  max-inline-size: 92vw;
   padding: 3rem 0;
-  background-color: var(--calcite-ui-foreground-1);
 
   a {
     text-decoration: none;
@@ -16,10 +16,10 @@
   }
 
   img {
-    inline-size: 100%;
-    block-size: auto;
     aspect-ratio: 342 / 192;
-    object-fit: cover; 
+    block-size: auto;
+    inline-size: 100%;
+    object-fit: cover;
     object-position: center;
   }
 
@@ -36,26 +36,26 @@
 
   & > a > div {
     border: 1px solid var(--calcite-ui-border-1);
-    margin: var(--space-2);
     cursor: pointer;
+    margin: var(--space-2);
 
     & > p {
       position: relative;
 
       & > button {
+        align-items: center;
+        background-color: var(--calcite-ui-foreground-2);
+        block-size: 50px;
+        border-radius: 50%;
         color: var(--calcite-ui-text-1);
-        position: absolute;
+        display: flex;
+        inline-size: 50px;
         inset-block-start: calc(50% - 25px);
         inset-inline-start: calc(50% - 25px);
-        border-radius: 50%;
-        inline-size: 50px;
-        block-size: 50px;
+        justify-content: center;
         margin: 0;
         padding: 0;
-        background-color: var(--calcite-ui-foreground-2);
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        position: absolute;
       }
     }
 
@@ -68,20 +68,20 @@
     }
 
     & > ul {
-      list-style-type: none;
-      padding: var(--space-5) var(--space-5) var(--space-6) var(--space-5);
-      margin: 0;
       block-size: 124px;
       box-sizing: border-box;
+      list-style-type: none;
+      margin: 0;
+      padding: var(--space-5) var(--space-5) var(--space-6) var(--space-5);
     }
   }
 }
 
 @media (width >= 768px) {
   .video-cards {
-    max-inline-size: 96vw;
     flex-flow: row wrap;
     justify-content: center;
+    max-inline-size: 96vw;
 
     & > a > div {
       inline-size: 45.5vw;

--- a/eds/styles/fonts.css
+++ b/eds/styles/fonts.css
@@ -9,361 +9,361 @@
 @import url("//fast.fonts.net/t/1.css?apiType=css&projectid=f9e335c8-e150-4885-976e-f4c392e562c4");
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/77156710-6a58-4606-b189-b4185e75967b.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/77156710-6a58-4606-b189-b4185e75967b.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/77caabd3-1877-4634-85c8-8e398a093b99.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/77caabd3-1877-4634-85c8-8e398a093b99.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/014f2daa-c310-4a36-b9fd-79a8e0c48d44.woff2") format("woff2");
-    font-weight: 400;
-    font-style: italic;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: italic;
+  font-weight: 400;
+  src: url("../fonts/014f2daa-c310-4a36-b9fd-79a8e0c48d44.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/b0b84e4d-2164-45c7-a674-1662f19f3ba6-basic.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/b0b84e4d-2164-45c7-a674-1662f19f3ba6-basic.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/e78b17bb-11fb-4860-8d66-4ee0d0c1e117.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/e78b17bb-11fb-4860-8d66-4ee0d0c1e117.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/77156710-6a58-4606-b189-b4185e75967b-ext.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/77156710-6a58-4606-b189-b4185e75967b-ext.woff2") format("woff2");
+  unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/77caabd3-1877-4634-85c8-8e398a093b99-ext.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/77caabd3-1877-4634-85c8-8e398a093b99-ext.woff2") format("woff2");
+  unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/014f2daa-c310-4a36-b9fd-79a8e0c48d44-ext.woff2") format("woff2");
-    font-weight: 400;
-    font-style: italic;
-    unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: italic;
+  font-weight: 400;
+  src: url("../fonts/014f2daa-c310-4a36-b9fd-79a8e0c48d44-ext.woff2") format("woff2");
+  unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/b0b84e4d-2164-45c7-a674-1662f19f3ba6-ext.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/b0b84e4d-2164-45c7-a674-1662f19f3ba6-ext.woff2") format("woff2");
+  unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/e78b17bb-11fb-4860-8d66-4ee0d0c1e117-ext.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/e78b17bb-11fb-4860-8d66-4ee0d0c1e117-ext.woff2") format("woff2");
+  unicode-range: U+0100-017F, U+0180-024F, U+1E00-1EFF, U+02B0-02FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/77156710-6a58-4606-b189-b4185e75967b-greek.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+0370-03FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/77156710-6a58-4606-b189-b4185e75967b-greek.woff2") format("woff2");
+  unicode-range: U+0370-03FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/77caabd3-1877-4634-85c8-8e398a093b99-greek.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+0370-03FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/77caabd3-1877-4634-85c8-8e398a093b99-greek.woff2") format("woff2");
+  unicode-range: U+0370-03FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/014f2daa-c310-4a36-b9fd-79a8e0c48d44-greek.woff2") format("woff2");
-    font-weight: 400;
-    font-style: italic;
-    unicode-range: U+0370-03FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: italic;
+  font-weight: 400;
+  src: url("../fonts/014f2daa-c310-4a36-b9fd-79a8e0c48d44-greek.woff2") format("woff2");
+  unicode-range: U+0370-03FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/a1049d00-54ad-4589-95b8-d353f7ab52f0-greek.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+0370-03FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/a1049d00-54ad-4589-95b8-d353f7ab52f0-greek.woff2") format("woff2");
+  unicode-range: U+0370-03FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/e78b17bb-11fb-4860-8d66-4ee0d0c1e117-greek.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+0370-03FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/e78b17bb-11fb-4860-8d66-4ee0d0c1e117-greek.woff2") format("woff2");
+  unicode-range: U+0370-03FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/174d458a-81e0-4174-9473-35e3bf0a613c.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+0400-04FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/174d458a-81e0-4174-9473-35e3bf0a613c.woff2") format("woff2");
+  unicode-range: U+0400-04FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/7db1f672-3a8f-4d19-9c49-7f61aed450b5.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+0400-04FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/7db1f672-3a8f-4d19-9c49-7f61aed450b5.woff2") format("woff2");
+  unicode-range: U+0400-04FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/b17468ea-cf53-4635-984b-4d930a68ed4d.woff2") format("woff2");
-    font-weight: 400;
-    font-style: italic;
-    unicode-range: U+0400-04FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: italic;
+  font-weight: 400;
+  src: url("../fonts/b17468ea-cf53-4635-984b-4d930a68ed4d.woff2") format("woff2");
+  unicode-range: U+0400-04FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/b0b84e4d-2164-45c7-a674-1662f19f3ba6.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+0400-04FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/b0b84e4d-2164-45c7-a674-1662f19f3ba6.woff2") format("woff2");
+  unicode-range: U+0400-04FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/40d36b4a-60c6-460a-bf43-4c948c23563e.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+0400-04FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/40d36b4a-60c6-460a-bf43-4c948c23563e.woff2") format("woff2");
+  unicode-range: U+0400-04FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/281f890c-8412-4ee3-84ed-8b5d062d2ab8.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+10A0-10FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/281f890c-8412-4ee3-84ed-8b5d062d2ab8.woff2") format("woff2");
+  unicode-range: U+10A0-10FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/281f890c-8412-4ee3-84ed-8b5d062d2ab8.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+10A0-10FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/281f890c-8412-4ee3-84ed-8b5d062d2ab8.woff2") format("woff2");
+  unicode-range: U+10A0-10FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/1fed34fa-250a-4d32-9f1d-42f978a2e0b2.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+10A0-10FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/1fed34fa-250a-4d32-9f1d-42f978a2e0b2.woff2") format("woff2");
+  unicode-range: U+10A0-10FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/2200dfff-da50-40b0-bc12-5e4b872a1998.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+10A0-10FF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/2200dfff-da50-40b0-bc12-5e4b872a1998.woff2") format("woff2");
+  unicode-range: U+10A0-10FF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/2a1ae9a5-b6b5-405c-b660-bbdf1b356952.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/2a1ae9a5-b6b5-405c-b660-bbdf1b356952.woff2") format("woff2");
+  unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/6ea5fa46-5311-450b-8744-288a30c55348.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/6ea5fa46-5311-450b-8744-288a30c55348.woff2") format("woff2");
+  unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/97694c53-4e94-4f9e-969b-a148adfcdcfd.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/97694c53-4e94-4f9e-969b-a148adfcdcfd.woff2") format("woff2");
+  unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/97694c53-4e94-4f9e-969b-a148adfcdcfd.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/97694c53-4e94-4f9e-969b-a148adfcdcfd.woff2") format("woff2");
+  unicode-range: U+0600-06FF, U+FB50-FDFF, U+FE70-FEFF;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/31da4b04-f98a-4b5f-b545-a31d26da99e5.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+0590-05FF, U+FB00-FB4F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/31da4b04-f98a-4b5f-b545-a31d26da99e5.woff2") format("woff2");
+  unicode-range: U+0590-05FF, U+FB00-FB4F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/31da4b04-f98a-4b5f-b545-a31d26da99e5.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+0590-05FF, U+FB00-FB4F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/31da4b04-f98a-4b5f-b545-a31d26da99e5.woff2") format("woff2");
+  unicode-range: U+0590-05FF, U+FB00-FB4F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/32a2c5cf-6736-44a6-a276-49ba7e030944.woff2") format("woff2");
-    font-weight: 400;
-    font-style: italic;
-    unicode-range: U+0590-05FF, U+FB00-FB4F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: italic;
+  font-weight: 400;
+  src: url("../fonts/32a2c5cf-6736-44a6-a276-49ba7e030944.woff2") format("woff2");
+  unicode-range: U+0590-05FF, U+FB00-FB4F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/a9eaf4d3-6427-42df-9306-3ea1270f7b1a.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+0590-05FF, U+FB00-FB4F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/a9eaf4d3-6427-42df-9306-3ea1270f7b1a.woff2") format("woff2");
+  unicode-range: U+0590-05FF, U+FB00-FB4F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/a9eaf4d3-6427-42df-9306-3ea1270f7b1a.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+0590-05FF, U+FB00-FB4F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/a9eaf4d3-6427-42df-9306-3ea1270f7b1a.woff2") format("woff2");
+  unicode-range: U+0590-05FF, U+FB00-FB4F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/94aa531e-7746-4df0-bb6e-349891f2eda5.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    unicode-range: U+0900-097F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/94aa531e-7746-4df0-bb6e-349891f2eda5.woff2") format("woff2");
+  unicode-range: U+0900-097F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/3ae1e25e-3aa6-4061-a016-a079159f9d65.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    unicode-range: U+0900-097F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/3ae1e25e-3aa6-4061-a016-a079159f9d65.woff2") format("woff2");
+  unicode-range: U+0900-097F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/41331c3c-3759-4462-8695-33c9a21b6a5b.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    unicode-range: U+0900-097F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/41331c3c-3759-4462-8695-33c9a21b6a5b.woff2") format("woff2");
+  unicode-range: U+0900-097F;
 }
 
 @font-face {
-    font-family: "Avenir Next";
-    src: url("../fonts/41331c3c-3759-4462-8695-33c9a21b6a5b.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    unicode-range: U+0900-097F;
-    font-display: auto;
+  font-display: auto;
+  font-family: "Avenir Next";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/41331c3c-3759-4462-8695-33c9a21b6a5b.woff2") format("woff2");
+  unicode-range: U+0900-097F;
 }
 
 @font-face {
-    font-family: "SST Vietnamese";
-    src: url("../fonts/c4cc9032-7eee-4a6e-ae8b-f384b1349bcf.woff2") format("woff2");
-    font-weight: 300;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "SST Vietnamese";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/c4cc9032-7eee-4a6e-ae8b-f384b1349bcf.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "SST Vietnamese";
-    src: url("../fonts/c1905e2e-a1cb-49de-9bb0-ce3c5ffc85ae.woff2") format("woff2");
-    font-weight: 400;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "SST Vietnamese";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/c1905e2e-a1cb-49de-9bb0-ce3c5ffc85ae.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "SST Vietnamese";
-    src: url("../fonts/18629a56-2ec3-4470-a65f-f82d7ec4d41b.woff2") format("woff2");
-    font-weight: 500;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "SST Vietnamese";
+  font-style: normal;
+  font-weight: 500;
+  src: url("../fonts/18629a56-2ec3-4470-a65f-f82d7ec4d41b.woff2") format("woff2");
 }
 
 @font-face {
-    font-family: "SST Vietnamese";
-    src: url("../fonts/4daa2125-53c6-4da8-9614-8a1049eaccc2.woff2") format("woff2");
-    font-weight: 700;
-    font-style: normal;
-    font-display: auto;
+  font-display: auto;
+  font-family: "SST Vietnamese";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/4daa2125-53c6-4da8-9614-8a1049eaccc2.woff2") format("woff2");
 }

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -419,113 +419,113 @@ main {
 
 /* Grid leader trailer spacing */
 .leader-0 {
-	margin-block-start: 0;
+  margin-block-start: 0;
 }
 
 .trailer-0 {
-	margin-block-end: 0;
+  margin-block-end: 0;
 }
 
 .padding-leader-0 {
-	padding-block-start: 0;
+  padding-block-start: 0;
 }
 
 .padding-trailer-0 {
-	padding-block-end: 0;
+  padding-block-end: 0;
 }
 
 .leader-1 {
-	margin-block-start: 1.5rem;
+  margin-block-start: 1.5rem;
 }
 
 .trailer-1 {
-	margin-block-end: 1.5rem;
+  margin-block-end: 1.5rem;
 }
 
 .padding-leader-1 {
-	padding-block-start: 1.5rem;
+  padding-block-start: 1.5rem;
 }
 
 .padding-trailer-1 {
-	padding-block-end: 1.5rem;
+  padding-block-end: 1.5rem;
 }
 
 .leader-2 {
-	margin-block-start: 3rem;
+  margin-block-start: 3rem;
 }
 
 .trailer-2 {
-	margin-block-end: 3rem;
+  margin-block-end: 3rem;
 }
 
 .padding-leader-2 {
-	padding-block-start: 3rem;
+  padding-block-start: 3rem;
 }
 
 .padding-trailer-2 {
-	padding-block-end: 3rem;
+  padding-block-end: 3rem;
 }
 
 .leader-3 {
-	margin-block-start: 4.5rem;
+  margin-block-start: 4.5rem;
 }
 
 .trailer-3 {
-	margin-block-end: 4.5rem;
+  margin-block-end: 4.5rem;
 }
 
 .padding-leader-3 {
-	padding-block-start: 4.5rem;
+  padding-block-start: 4.5rem;
 }
 
 .padding-trailer-3 {
-	padding-block-end: 4.5rem;
+  padding-block-end: 4.5rem;
 }
 
 .leader-4 {
-	margin-block-start: 6rem;
+  margin-block-start: 6rem;
 }
 
 .trailer-4 {
-	margin-block-end: 6rem;
+  margin-block-end: 6rem;
 }
 
 .padding-leader-4 {
-	padding-block-start: 6rem;
+  padding-block-start: 6rem;
 }
 
 .padding-trailer-4 {
-	padding-block-end: 6rem;
+  padding-block-end: 6rem;
 }
 
 .leader-5 {
-	margin-block-start: 7.5rem;
+  margin-block-start: 7.5rem;
 }
 
 .trailer-5 {
-	margin-block-end: 7.5rem;
+  margin-block-end: 7.5rem;
 }
 
 .padding-leader-5 {
-	padding-block-start: 7.5rem;
+  padding-block-start: 7.5rem;
 }
 
 .padding-trailer-5 {
-	padding-block-end: 7.5rem;
+  padding-block-end: 7.5rem;
 }
 
 .leader-6 {
-	margin-block-start: 9rem;
+  margin-block-start: 9rem;
 }
 
 .trailer-6 {
-	margin-block-end: 9rem;
+  margin-block-end: 9rem;
 }
 
 .padding-leader-6 {
-	padding-block-start: 9rem;
+  padding-block-start: 9rem;
 }
 
 .padding-trailer-6 {
-	padding-block-end: 9rem;
+  padding-block-end: 9rem;
 }


### PR DESCRIPTION
Ran `stylelint --fix` on CSS to fix linter errors introduced by the updated configuration.

Fix #474 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://474-stylelint-fix--esri-eds--esri.aem.live/
