### PR TITLE
updated spacing for tls equivalent

### DIFF
--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -39,10 +39,6 @@
     h3, p:last-child {
       padding-inline-end: var(--space-5);
     }
-
-    & > *:first-child {
-      margin-block: 0 2rem;
-    }
   }
 
   .cards-card-image {


### PR DESCRIPTION
- Removed extra spacing between icon and content

Fix #438 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/indoor-gis/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
- After: https://tlsspacing--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
