### PR TITLE
Columns Align CTAs in row

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -11,8 +11,8 @@
 }
 
 .columns > div > div :where(h2, p,.button-container) {
-  padding-inline: var(--space-12);
   margin: var(--space-2) var(--space-8);
+  padding-inline: var(--space-12);
 }
 
 .columns > div > div .button-container a {
@@ -60,14 +60,14 @@
   }
 
   .columns > div > div:nth-of-type(1) > .buttons-container {
-    max-inline-size: 720px;
     margin-inline-start: auto;
+    max-inline-size: 720px;
   }
 
   .columns > div > div :where(h2, p, .buttons-container) {
     margin: 0;
-    max-inline-size: 720px;
     margin-inline-start: auto;
+    max-inline-size: 720px;
     padding-inline: var(--space-12);
   }
 

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -2,20 +2,21 @@
   display: flex;
 }
 
-.columns > div:has(div > :is(h2, p)) {
+.columns > div:has(div > :where(h2)) {
   flex-direction: column-reverse;
 }
 
-.columns > div:has(div:nth-of-type(1) > :is(h2, p)) {
+.columns > div:has(div:nth-of-type(1) > :where(h2)) {
   flex-direction: column;
 }
 
-.columns > div > div:last-child {
-  padding-block-end: 32px;
+.columns > div > div :where(h2, p,.button-container) {
+  padding-inline: var(--space-12);
+  margin: var(--space-2) var(--space-8);
 }
 
-.columns > div > div :where(h2, p) {
-  margin: 0 var(--space-8);
+.columns > div > div .button-container a {
+  margin-block-start: var(--space-6);
 }
 
 .columns > div > .columns-img-col {
@@ -54,14 +55,29 @@
     flex: 1;
   }
 
-  .columns > div > div:nth-of-type(2) :where(h2, p) {
+  .columns > div > div:nth-of-type(2) :where(h2, p, .buttons-container) {
     margin-inline: 0 auto;
   }
 
-  .columns > div > div :where(h2, p) {
-    margin-inline-start: auto;
+  .columns > div > div:nth-of-type(1) > .buttons-container {
     max-inline-size: 720px;
+    margin-inline-start: auto;
+  }
+
+  .columns > div > div :where(h2, p, .buttons-container) {
+    margin: 0;
+    max-inline-size: 720px;
+    margin-inline-start: auto;
     padding-inline: var(--space-12);
+  }
+
+  .columns > div > div .buttons-container {
+    padding-inline: var(--space-12) 0;
+  }
+
+  .columns > div > div .buttons-container p {
+    display: inline-block;
+    padding-inline: 0 var(--space-3);
   }
 }
 

--- a/eds/blocks/columns/columns.js
+++ b/eds/blocks/columns/columns.js
@@ -13,6 +13,17 @@ export default function decorate(block) {
           picWrapper.classList.add('columns-img-col');
         }
       }
+
+      const buttons = col.querySelectorAll('.button-container');
+      if (buttons.length > 0) {
+        const parent = buttons[0].parentElement;
+        const buttonWrapper = document.createElement('div');
+        buttonWrapper.classList.add('buttons-container');
+        buttons.forEach((btn) => {
+          buttonWrapper.appendChild(btn);
+        });
+        parent.appendChild(buttonWrapper);
+      }
     });
   });
 }


### PR DESCRIPTION
Align CTA buttons in same row on desktop, stack on mobile view. 

![50spt](https://github.com/user-attachments/assets/1f37b6f4-5531-4a63-b2ac-497b634d1c17)

Fix #458

**Test URLs (50/50):**
- Original: https://www.esri.com/en-us/capabilities/mapping/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/mapping/overview  
- After: https://ctaAlign--esri-eds--esri.aem.live/en-us/capabilities/mapping/overview 

![cta50](https://github.com/user-attachments/assets/8ac1d296-73ad-43d5-ba95-ee0fba45224e)

![50mobile](https://github.com/user-attachments/assets/052068dd-e85b-4d1f-a896-cd4f8713b5ac)

**Test URLs (Media Split):**
- Original: https://www.esri.com/en-us/capabilities/geoai/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview
- After: https://ctaAlign--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview

![ms-cta](https://github.com/user-attachments/assets/1513e3b6-9bdf-424f-9bd5-fb38c9fecb53)

![ms-mobile](https://github.com/user-attachments/assets/3c1a63e4-2920-4a8a-bbf3-4d463a8ce84a)

