### PR TITLE
Media Split align image towards center half of viewport 

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -97,8 +97,8 @@
 
   .columns.media-split > div > .columns-img-col img {
     margin-block: var(--space-10);
-    padding-inline: 0;
     margin-inline-end: var(--space-20);
+    padding-inline: 0;
   }
 }
 

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -29,10 +29,10 @@
 }
 
 .columns > div > .columns-img-col img {
+  block-size: 100%;
   display: block;
   inline-size: 100%;
   margin-inline-start: auto;
-  block-size: 100%;
   object-fit: cover;
 }
 
@@ -96,8 +96,8 @@
   }
 
   .columns.media-split > div > .columns-img-col img {
-    padding-inline: 0;
     margin-block: var(--space-10);
+    padding-inline: 0;
     margin-inline-end: var(--space-20);
   }
 }

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -24,13 +24,19 @@
   display: block;
 }
 
+.columns.media-split > div > .columns-img-col img {
+  padding-inline: var(--space-6);
+}
+
 .columns > div > :not(.columns-img-col) {
   padding: var(--space-16) 0 var(--space-20);
 }
 
 .columns > div > .columns-img-col img {
-  block-size: 100%;
   display: block;
+  inline-size: 100%;
+  margin-inline-start: auto;
+  block-size: 100%;
   object-fit: cover;
 }
 
@@ -41,6 +47,10 @@
 @media (width >= 900px) {
   .columns > div {
     align-items: center;
+  }
+
+  .columns-wrapper > .columns.media-split  {
+    padding-inline: var(--space-6);
   }
 
   .columns > div:has(div > :is(h2, p), div:nth-of-type(1) > :is(h2, p)) {
@@ -69,6 +79,16 @@
     margin-inline-start: auto;
     max-inline-size: 720px;
     padding-inline: var(--space-12);
+  }
+
+  .columns > div > .columns-img-col img {
+    inline-size: auto;
+  }
+
+  .columns.media-split > div > .columns-img-col img {
+    padding-inline: 0;
+    margin-block: var(--space-10);
+    margin-inline-end: var(--space-20);
   }
 
   .columns > div > div .buttons-container {

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -24,10 +24,6 @@
   display: block;
 }
 
-.columns.media-split > div > .columns-img-col img {
-  padding-inline: var(--space-6);
-}
-
 .columns > div > :not(.columns-img-col) {
   padding: var(--space-16) 0 var(--space-20);
 }
@@ -42,6 +38,10 @@
 
 .columns.calcite-mode-gray {
   background-color: var(--calcite-ui-foreground-2);
+}
+
+.columns.media-split > div > .columns-img-col img {
+  padding-inline: var(--space-6);
 }
 
 @media (width >= 900px) {
@@ -81,11 +81,6 @@
     inline-size: auto;
   }
 
-  .columns.media-split > div > .columns-img-col img {
-    padding-inline: 0;
-    margin-block: var(--space-10);
-    margin-inline-end: var(--space-20);
-  }
 
   .columns > div > div .buttons-container {
     padding-inline: var(--space-12) 0;
@@ -94,6 +89,16 @@
   .columns > div > div .buttons-container p {
     display: inline-block;
     padding-inline: 0 var(--space-3);
+  }
+
+  .columns-wrapper > .columns.media-split  {
+    padding-inline: var(--space-6);
+  }
+
+  .columns.media-split > div > .columns-img-col img {
+    padding-inline: 0;
+    margin-block: var(--space-10);
+    margin-inline-end: var(--space-20);
   }
 }
 

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -49,10 +49,6 @@
     align-items: center;
   }
 
-  .columns-wrapper > .columns.media-split  {
-    padding-inline: var(--space-6);
-  }
-
   .columns > div:has(div > :is(h2, p), div:nth-of-type(1) > :is(h2, p)) {
     flex-direction: row;
   }


### PR DESCRIPTION
![50spt](https://github.com/user-attachments/assets/77f2e38a-fa11-42b9-be19-503238b77f3a)

Fix #486 

Test URLs: (media split)
- Original: https://www.esri.com/en-us/capabilities/geoai/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview
- After: https://imgAlign--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview

![img1440](https://github.com/user-attachments/assets/137f79ad-a6e6-4379-8d46-e1e8bc5fbf17)

![ms1220](https://github.com/user-attachments/assets/895ab1a3-6f3a-4af1-9964-58a61fbda751)

![msmobile](https://github.com/user-attachments/assets/c07e71d2-a48b-4572-a148-96133c97d1fd)


Test URLs: (50/50)
- Original: https://www.esri.com/en-us/capabilities/data-management
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management
- After: https://imgAlign--esri-eds--esri.aem.live/en-us/capabilities/data-management
