### PR TITLE
ECS-update button to calcite link and text color

### DIFF
--- a/eds/blocks/elastic-content-strip/elastic-content-strip.css
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.css
@@ -12,6 +12,15 @@
   text-decoration: none;
 }
 
+.elastic-content-link-wrapper p {
+  color: var(--calcite-ui-text-1);
+}
+
+.elastic-content-link-wrapper calcite-link {
+  --calcite-ui-text-link: var(--calcite-ui-text-1);
+  --calcite-link-blue-underline: transparent;
+}
+
 .elastic-content-link-wrapper > div {
   inline-size: 85%;
   margin-inline: auto;

--- a/eds/blocks/elastic-content-strip/elastic-content-strip.js
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.js
@@ -20,11 +20,11 @@ export default function decorate(block) {
     const btn = div.querySelector('.button-container');
     const labelText = btn.querySelector('a').textContent;
     const btnLink = calciteLink({
-          'icon-end': 'arrowRight',
-          class: 'button link',
-          href: linkHref,
-          label: labelText,
-        }, labelText);
+      'icon-end': 'arrowRight',
+      class: 'button link',
+      href: linkHref,
+      label: labelText,
+    }, labelText);
     btn.replaceWith(btnLink);
   });
 

--- a/eds/blocks/elastic-content-strip/elastic-content-strip.js
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.js
@@ -1,4 +1,4 @@
-import { a } from '../../scripts/dom-helpers.js';
+import { a, calciteLink } from '../../scripts/dom-helpers.js';
 
 import {
   decorateInnerHrefButtonsWithArrowIcon,
@@ -15,13 +15,17 @@ export default function decorate(block) {
     });
     div.parentNode.insertBefore(elasticContentWrapper, div);
     elasticContentWrapper.appendChild(div);
-
     decorateInnerHrefButtonsWithArrowIcon(elasticContentWrapper);
-  });
 
-  block.querySelectorAll('.button-container').forEach((bc) => {
-    bc.children[0].classList.remove('button');
-    bc.children[0].classList.add('learn-more-icon-container');
+    const btn = div.querySelector('.button-container');
+    const labelText = btn.querySelector('a').textContent;
+    const btnLink = calciteLink({
+          'icon-end': 'arrowRight',
+          class: 'button link',
+          href: linkHref,
+          label: labelText,
+        }, labelText);
+    btn.replaceWith(btnLink);
   });
 
   decorateBlockMode(block);


### PR DESCRIPTION
- Updated text color to match prod.
- Updated button to a calcite link 

Fix #488 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/real-time/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/real-time/overview
- After: https://ecsbutton--esri-eds--esri.aem.live/en-us/capabilities/real-time/overview
