### PR TITLE
Media Split center text for mobile/tablet

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -10,13 +10,16 @@
   flex-direction: column;
 }
 
-.columns > div > div :where(h2, p,.button-container) {
+.columns > div > div :where(h2, p) {
   margin: var(--space-2) var(--space-8);
-  padding-inline: var(--space-12);
+}
+
+.columns > div > div .button-container {
+  margin-block: var(--space-4) var(--space-1);
 }
 
 .columns > div > div .button-container a {
-  margin-block-start: var(--space-6);
+  margin-block: var(--space-1) 0;
 }
 
 .columns > div > .columns-img-col {
@@ -42,6 +45,10 @@
 
 .columns.media-split > div > .columns-img-col img {
   padding-inline: var(--space-6);
+}
+
+.columns.media-split > div > div .buttons-container {
+  text-align: center;
 }
 
 @media (width >= 900px) {
@@ -81,14 +88,13 @@
     inline-size: auto;
   }
 
-
-  .columns > div > div .buttons-container {
-    padding-inline: var(--space-12) 0;
-  }
-
   .columns > div > div .buttons-container p {
     display: inline-block;
     padding-inline: 0 var(--space-3);
+  }
+
+ .columns.columns.media-split > div > div :where(h2, p, .buttons-container) {
+    text-align: start;
   }
 
   .columns-wrapper > .columns.media-split  {
@@ -118,5 +124,13 @@
 
   & > div > div h2 {
     margin-block-end: var(--space-2);
+  }
+
+  & > div > div :where(h2, p) {
+    text-align: center;
+  }
+
+  & > div > div .button-container {
+    display: inline-block;
   }
 }


### PR DESCRIPTION
Fix #485 

Test URLs: (media split)
- Original: https://www.esri.com/en-us/capabilities/geoai/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview
- After: https://alignTxtC--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview

![msCATm](https://github.com/user-attachments/assets/40aa5638-fd53-4404-81aa-6e3f241b2009)
![msCATT](https://github.com/user-attachments/assets/0fc8ae7b-79b8-44ab-989e-3f570460942f)



Test URLs: (50/50)
- Original: https://www.esri.com/en-us/capabilities/data-management
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management
- After: https://alignTxtC--esri-eds--esri.aem.live/en-us/capabilities/data-management
