### PR TITLE
image switcher-updated styles

### DIFF
--- a/eds/blocks/image-switcher/image-switcher.css
+++ b/eds/blocks/image-switcher/image-switcher.css
@@ -178,7 +178,7 @@
     inline-size: 100%;
 
     .nav-list {
-      flex-direction: column;
+      flex-direction: row;
       inline-size: 100%;
 
       .nav-item {
@@ -199,6 +199,7 @@
         img {
           block-size: 60px;
           inline-size: 60px;
+          max-inline-size: 60px;
         }
       }
 


### PR DESCRIPTION
**Fixed the following issues:**
- Images are in oval shape unlike round shape in prod.
- The sequence of image switcher cards is incorrect.
- Cards are not wrapped in the correct order.

Fix #493 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
- After: https://imageswitcher--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
