### PR TITLE
Media Text Split image container

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -105,6 +105,10 @@
     padding-inline: var(--space-6);
   }
 
+  .columns.media-split > div > div {
+    inline-size: 50vw;
+  }
+
   .columns.media-split > div > .columns-img-col img {
     margin-block: var(--space-10);
     margin-inline-end: var(--space-20);

--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -84,6 +84,10 @@
     padding-inline: var(--space-12);
   }
 
+  .columns > div > div p.columns-p {
+    padding-inline: 0;
+  }
+
   .columns > div > .columns-img-col img {
     inline-size: auto;
   }

--- a/eds/blocks/columns/columns.js
+++ b/eds/blocks/columns/columns.js
@@ -24,6 +24,12 @@ export default function decorate(block) {
         });
         parent.appendChild(buttonWrapper);
       }
+
+      // media text split logic
+      const p = col.querySelector('p');
+      if (p?.querySelector('picture')) {
+        p.classList.add('columns-p');
+      }
     });
   });
 }


### PR DESCRIPTION
Media Text Split wraps <picture> element inside a <p> element where as Media Split does not wrap <picture> element inside a <p> element. Add class 'column-p' to Media Text Split. This addition allows for style differences between Media Text Split and Media Split.

![50spt](https://github.com/user-attachments/assets/77f2e38a-fa11-42b9-be19-503238b77f3a)

Fix #492

Test URLs: **(Media Text Split)**
- Original: https://www.esri.com/en-us/capabilities/indoor-gis/capabilities/indoor-data-collection
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/capabilities/indoor-data-collection
- After: https://mts50--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/capabilities/indoor-data-collection

![mtsbefore](https://github.com/user-attachments/assets/b73154ad-c9c5-4fb5-87b2-b8b4da0728bd)

![mtsafter](https://github.com/user-attachments/assets/bf31e236-a805-47f0-a203-77bc75555db4)

Test URLs: **(Media Split)**
- Original: https://www.esri.com/en-us/en-us/capabilities/geoai/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview
- After: https://mts50--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview

Test URLs: **(50-50)**
- Original: https://www.esri.com/en-us/capabilities/data-management
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management
- After: https://mts50--esri-eds--esri.aem.live/en-us/capabilities/data-management
