### PR TITLE
50-50 overflow hidden

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -58,6 +58,7 @@
 
   .columns > div:has(div > :is(h2, p), div:nth-of-type(1) > :is(h2, p)) {
     flex-direction: row;
+    overflow: hidden;
   }
 
   .columns:not(.media-split) > div {


### PR DESCRIPTION
Hide Content Overflow in tablet view.

![50spt](https://github.com/user-attachments/assets/77f2e38a-fa11-42b9-be19-503238b77f3a)

Fix #496 

Test URLs: **(50-50)**
- Original: https://www.esri.com/en-us/capabilities/data-management
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/data-management
- After: https://fiftyOverflow--esri-eds--esri.aem.live/en-us/capabilities/data-management

![overflowAfter](https://github.com/user-attachments/assets/168e603f-7fae-430f-8e36-f29b875031c2)

![overflowBefore](https://github.com/user-attachments/assets/eae9235c-1ee7-4a4d-b708-a7be99b8ddfd)

Test URLs: **(Media Text Split)**
- Original: https://www.esri.com/en-us/capabilities/indoor-gis/capabilities/indoor-data-collection
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/capabilities/indoor-data-collection
- After: https://fiftyOverflow--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/capabilities/indoor-data-collection

Test URLs: **(Media Split)**
- Original: https://www.esri.com/en-us/en-us/capabilities/geoai/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview
- After: https://fiftyOverflow--esri-eds--esri.aem.live/en-us/capabilities/geoai/overview