### PR TITLE
Autoplay Video, intersection observer added

### DIFF
--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -216,7 +216,6 @@ export function decorateBlockMode(block) {
 export function createAutoplayedVideo(sourceSrc, posterSrc = '') {
   const videoElem = video(
     {
-      autoplay: '',
       preload: 'metadata',
       playsinline: '',
       type: 'video/mp4',
@@ -228,6 +227,23 @@ export function createAutoplayedVideo(sourceSrc, posterSrc = '') {
   if (posterSrc) {
     videoElem.setAttribute('poster', posterSrc);
   }
+
+  /**
+   * IntersectionObserver to play or pause a video element based on its visibility.
+   * The video element will be played when the intersection ratio exceeds 0.8.
+   * Otherwise, the video element will pause.
+   */
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.intersectionRatio > 0.8) {
+        videoElem.play();
+      } else {
+        videoElem.pause();
+      }
+    });
+  }, { threshold: [0, 0.8] });
+
+  observer.observe(videoElem);
 
   return videoElem;
 }

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -286,7 +286,7 @@ function decorateIcons(element, prefix = '') {
  * Decorates the main element.
  * @param {Element} main The main element
  */
-// eslint-disable-next-line import/prefer-default-export
+
 export function decorateMain(main) {
   // hopefully forward compatible button decoration
   decorateButtons(main);
@@ -358,7 +358,6 @@ async function loadLazy(doc) {
  * without impacting the user experience.
  */
 function loadDelayed() {
-  // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 4000);
   // load anything that can be postponed to the latest here
   addAnimation();

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -206,6 +206,13 @@ export function decorateBlockMode(block) {
   decorateMode(block);
 }
 
+/**
+ * Creates an autoplayed video element with the given source and optional poster.
+ *
+ * @param {string} sourceSrc - The source URL of the video.
+ * @param {string} [posterSrc=''] - The optional poster image URL for the video.
+ * @returns {HTMLElement} The created video element.
+ */
 export function createAutoplayedVideo(sourceSrc, posterSrc = '') {
   const videoElem = video(
     {


### PR DESCRIPTION
Add intersection observer to video code. Currently set at 80%. Appears to solve the autoplay issues. 

Fix #501

Test URLs:
- Original: https://www.esri.com/en-us/location-intelligence/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/location-intelligence/overview
- After: https://video--esri-eds--esri.aem.live/en-us/location-intelligence/overview
