### PR TITLE
Local nav cta updates

### DIFF
--- a/eds/blocks/local-navigation/local-navigation.css
+++ b/eds/blocks/local-navigation/local-navigation.css
@@ -13,7 +13,6 @@
 .local-navigation nav#main {
   align-items: flex-start;
   display: flex;
-  margin-inline-start: var(--space-4);
 }
 
 .local-navigation .navigation-title a {
@@ -250,7 +249,8 @@
 
   .local-navigation calcite-button {
     background-color: #2b2b2b;
-    padding-inline: var(--space-4);
+    margin: 8.5px 0 8.5px 10px;
+    padding: 0;
   }
 
   .local-navigation calcite-icon {

--- a/eds/blocks/local-navigation/local-navigation.css
+++ b/eds/blocks/local-navigation/local-navigation.css
@@ -249,11 +249,23 @@
 
   .local-navigation calcite-button {
     background-color: #2b2b2b;
-    margin: 8.5px 0 8.5px 10px;
+    margin: 8.5px 10px;
     padding: 0;
   }
 
   .local-navigation calcite-icon {
     display: none;
+  }
+}
+
+@media (width < 1600px) {
+  .local-navigation nav#main {
+    padding-inline-start: var(--space-8);
+  }
+}
+
+@media (width >= 1440px) {
+  .local-navigation calcite-button {
+    margin-inline: 10px 0;
   }
 }

--- a/eds/blocks/local-navigation/local-navigation.js
+++ b/eds/blocks/local-navigation/local-navigation.js
@@ -129,7 +129,7 @@ function decorateBlueButton(value, block) {
       href = value.triallink;
     }
     if (href) {
-      const trialBtn = domEl('calcite-button', { class: 'trial-button', href });
+      const trialBtn = domEl('calcite-button', { class: 'trial-button', href, scale: 'l' });
       trialBtn.innerHTML = value.triallabel;
       block.querySelector('nav > ul').appendChild(trialBtn);
     }


### PR DESCRIPTION
- The local navigation spacing has been adjusted to match the production environment. The gap between the local navigation and the section below is coming from the 'Hero' block.
-The Calcite button size has been updated to "large."
- Spacing has been adjusted to align the local navigation heading with the content above.
- Spacing has been replicated to match the production environment across different media sizes.

Fix #500 

Test URLs:
- Original: https://www.esri.com/en-us/location-intelligence/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/location-intelligence/overview
- After: https://localnavcta--esri-eds--esri.aem.live/en-us/location-intelligence/overview
