### PR TITLE
updated logic for links with relative paths

### DIFF
--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -416,7 +416,9 @@ function wrapTextNodes(block) {
 function decorateButtons(element) {
   element.querySelectorAll('a').forEach((a) => {
     a.title = a.title || a.textContent;
-    if (a.href !== a.textContent) {
+    const url = new URL(a.href);
+    const relativePath = url.pathname + url.search + url.hash;
+    if (a.href !== a.textContent && relativePath!==a.textContent ) {
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
       if (!a.querySelector('img')) {

--- a/eds/scripts/aem.js
+++ b/eds/scripts/aem.js
@@ -418,7 +418,7 @@ function decorateButtons(element) {
     a.title = a.title || a.textContent;
     const url = new URL(a.href);
     const relativePath = url.pathname + url.search + url.hash;
-    if (a.href !== a.textContent && relativePath!==a.textContent ) {
+    if (a.href !== a.textContent && relativePath !== a.textContent) {
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
       if (!a.querySelector('img')) {


### PR DESCRIPTION
- Have updated the if condition so it not only checks for the full url but also the relative path.
- This helps to cover the usecases with relative paths.

Fix #512 

Test URLs:
- Original: https://www.esri.com/en-us/digital-twin/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/digital-twin/overview
- After: https://relativepath--esri-eds--esri.aem.live/en-us/digital-twin/overview

rendered as buttons which should actually be links:
<img width="751" alt="Screenshot 2025-01-09 at 2 29 57 PM" src="https://github.com/user-attachments/assets/ea452fe2-b275-430d-b590-fe0c4a2374ed" />


