### PR TITLE
card simple with image - update width

### DIFF
--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -178,7 +178,7 @@
 
     img {
       block-size: 44px;
-      inline-size: 44px;
+      inline-size: auto;
       margin-block-end: var(--content-spacing);
     }
   }


### PR DESCRIPTION
Cards simple with image(not an icon) are shrinking the image size. Update the css so it takes the image width and is not hidden.

Fix #519

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/indoor-gis/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
- After: https://cardsimpleimage--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
