### PR TITLE
JS updates for all card versions

### DIFF
--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -39,6 +39,10 @@
     h3, p:last-child {
       padding-inline-end: var(--space-5);
     }
+
+    calcite-link {
+      display: block;
+    }
   }
 
   .cards-card-image {

--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -83,9 +83,14 @@ export default function decorate(block) {
         const pTags = element.querySelectorAll('p');
         titleSelector = (pTags.length >= 3) ? 'p:nth-last-child(2)' : 'p:nth-last-child(1)';
       } else if (!block.classList.contains('simple') && !block.classList.contains('standard')) {
-        titleSelector = (linksCount === 1) ? 'p:nth-last-child(3)' :
-            (linksCount === 2) ? 'p:nth-last-child(4)' : 'p:nth-last-child(3)';
-          }
+        if (linksCount === 1) {
+          titleSelector = 'p:nth-last-child(3)';
+        } else if (linksCount === 2) {
+          titleSelector = 'p:nth-last-child(4)';
+        } else {
+          titleSelector = 'p:nth-last-child(3)';
+        }
+      }
       if (titleSelector) {
         element.querySelectorAll(titleSelector).forEach((p) => {
           const h3 = document.createElement('h3');

--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -39,7 +39,7 @@ function processStandardCard(element) {
   const pictureEl = element.querySelector('picture').closest('p');
   const overlayTextEl = element.querySelector('.overlay-text');
   if (overlayTextEl) pictureEl.append(overlayTextEl);
-  if(pictureEl) {
+  if (pictureEl) {
     pictureEl.nextElementSibling.classList.add('card-body-title');
     const cardBodyTitle = element.querySelector('.card-body-title');
     if (cardBodyContent.lastChild.classList === '') cardBodyContent.lastChild.classList.add('card-body-description');
@@ -48,7 +48,6 @@ function processStandardCard(element) {
       cardBodyTitle.nextElementSibling.classList.add('card-body-subtitle');
     }
   }
- 
 }
 
 export default function decorate(block) {
@@ -82,12 +81,11 @@ export default function decorate(block) {
       let titleSelector;
       if (block.classList.contains('block-group')) {
         const pTags = element.querySelectorAll('p');
-        console.log('number of p '+pTags.length);
         titleSelector = (pTags.length >= 3) ? 'p:nth-last-child(2)' : 'p:nth-last-child(1)';
       } else if (!block.classList.contains('simple') && !block.classList.contains('standard')) {
         titleSelector = (linksCount === 1) ? 'p:nth-last-child(3)' :
             (linksCount === 2) ? 'p:nth-last-child(4)' : 'p:nth-last-child(3)';
-      }
+          }
       if (titleSelector) {
         element.querySelectorAll(titleSelector).forEach((p) => {
           const h3 = document.createElement('h3');

--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -36,18 +36,19 @@ function processStandardCard(element) {
       el.classList.add('overlay-text');
     }
   });
-  const pictureEl = element.querySelector('picture')
-    .closest('p');
+  const pictureEl = element.querySelector('picture').closest('p');
   const overlayTextEl = element.querySelector('.overlay-text');
   if (overlayTextEl) pictureEl.append(overlayTextEl);
-  pictureEl.nextElementSibling.classList.add('card-body-title');
-  const cardBodyTitle = element.querySelector('.card-body-title');
+  if(pictureEl) {
+    pictureEl.nextElementSibling.classList.add('card-body-title');
+    const cardBodyTitle = element.querySelector('.card-body-title');
+    if (cardBodyContent.lastChild.classList === '') cardBodyContent.lastChild.classList.add('card-body-description');
 
-  if (cardBodyContent.lastChild.classList === '') cardBodyContent.lastChild.classList.add('card-body-description');
-
-  if (cardBodyTitle.nextElementSibling && !cardBodyTitle.nextElementSibling.classList.contains('card-body-description')) {
-    cardBodyTitle.nextElementSibling.classList.add('card-body-subtitle');
+    if (cardBodyTitle.nextElementSibling && !cardBodyTitle.nextElementSibling.classList.contains('card-body-description')) {
+      cardBodyTitle.nextElementSibling.classList.add('card-body-subtitle');
+    }
   }
+ 
 }
 
 export default function decorate(block) {
@@ -76,9 +77,18 @@ export default function decorate(block) {
           p.replaceWith(button);
         }
       });
-      if (!block.classList.contains('simple')) {
-        const isLastChildLink = element.lastElementChild?.tagName.toLowerCase() === 'calcite-link';
-        const titleSelector = isLastChildLink ? 'p:nth-last-child(3)' : 'p:nth-last-child(2)';
+
+      const linksCount = element.querySelectorAll('calcite-link').length;
+      let titleSelector;
+      if (block.classList.contains('block-group')) {
+        const pTags = element.querySelectorAll('p');
+        console.log('number of p '+pTags.length);
+        titleSelector = (pTags.length >= 3) ? 'p:nth-last-child(2)' : 'p:nth-last-child(1)';
+      } else if (!block.classList.contains('simple') && !block.classList.contains('standard')) {
+        titleSelector = (linksCount === 1) ? 'p:nth-last-child(3)' :
+            (linksCount === 2) ? 'p:nth-last-child(4)' : 'p:nth-last-child(3)';
+      }
+      if (titleSelector) {
         element.querySelectorAll(titleSelector).forEach((p) => {
           const h3 = document.createElement('h3');
           h3.innerHTML = p.innerHTML;

--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -23,26 +23,6 @@
     margin-block-start: var(--space-5);
   }
 
-  .cards ul {
-    align-items: stretch;
-  }
-
-  .cards li {
-    block-size: 100%;
-    flex: 0 0 100%;
-  }
-
-  .cards a {
-    block-size: 100%;
-    color: var(--calcite-ui-text-1);
-    display: block;
-    text-decoration: none;
-  }
-
-  .cards-card-body :is(picture, img) {
-    aspect-ratio: 342 / 192;
-  }
-
   p:last-child {
     align-items: center;
     display: flex;
@@ -78,38 +58,6 @@
       font-size: var(--font-8);
       margin: 0;
       margin-block-end: 0.6rem;
-    }
-  }
-
-  .cards-card-body {
-    border: solid 1px var(--calcite-ui-border-1);
-    margin: var(--space-2);
-
-    & > p:first-child {
-      margin-block-end: 0;
-    }
-
-    & > p:nth-child(2) {
-      color: var(--calcite-ui-text-1);
-      font-size: var(--font-2);
-      margin-block-end: var(--space-2);
-      margin-inline: var(--space-5);
-    }
-
-    & > p:last-child {
-      color: var(--calcite-ui-text-1);
-      display: block;
-      font-size: var(--font-minus-1);
-      margin-block-end: var(--space-6);
-      margin-inline: var(--space-5);
-      padding: 0;
-    }
-
-    & > p:nth-child(3):not(:last-child) {
-      color: var(--calcite-ui-text-2);
-      font-size: var(--font-minus-1);
-      margin-block-end: var(--space-2);
-      margin-inline: var(--space-5);
     }
   }
 
@@ -231,17 +179,6 @@
       }
     }
   }
-
-  /* .tab-content .text-wrapper, .tab-content .buttons-wrapper {
-    animation-delay: 50ms;
-    animation-duration: 550ms;
-    animation-fill-mode: both;
-    animation-timing-function: ease-in-out;
-  }
-
-  .tab-content[aria-hidden='false'] .text-wrapper, .tab-content[aria-hidden='false'] .buttons-wrapper {
-    animation-name: in-up;
-  } */
 }
 
 @media (width >= 900px) {
@@ -257,10 +194,6 @@
 
 @media (width >= 1024px) {
   .tabs {
-    .cards li {
-      flex: 0 0 33.33%;
-    }
-
     .tab-component {
       position: relative;
     }
@@ -357,10 +290,6 @@
 }
 
 @media (width >= 1440px) {
-  .tabs .cards li {
-    flex: 0 0 25%;
-  }
-
   .tabs .columns {
     margin: auto;
   }

--- a/eds/blocks/tabs/tabs.js
+++ b/eds/blocks/tabs/tabs.js
@@ -47,25 +47,6 @@ export default async function decorate(block) {
     }, content));
   }
 
-  const isCardsVariant = contents?.every((content) => content.querySelectorAll('.cards').length > 0);
-  if (isCardsVariant) {
-    contents.forEach((content) => {
-      const cards = content.querySelectorAll('.cards-card-body');
-      cards.forEach((card) => {
-        const anchor = card.querySelector('a');
-        anchor.classList.remove('button');
-        anchor.textContent = '';
-
-        const cardParent = card.parentElement;
-        cardParent.removeChild(card);
-
-        anchor.parentElement.parentElement.removeChild(anchor.parentElement);
-        anchor.appendChild(card);
-        cardParent.appendChild(anchor);
-      });
-    });
-  }
-
   if (!tabsContainFragments) {
     tabContents.forEach((content) => {
       const text = [content[1], content[2], content[3]];


### PR DESCRIPTION
- Eliminated redundant code from the tabs block, ensuring the cards block now loads as expected, utilizing only the relevant JS and CSS for the cards.
- Refactored JS to ensure consistent title updates to H3 across all card versions.
- This PR ensures that all card versions are fully functional and display as expected.

Fix #178 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://cards--esri-eds--esri.aem.live/en-us/about/about-esri/americas

**Pages with cards(multiple versions):**

- http://main--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific
- http://main--esri-eds--esri.aem.live/en-us/about/about-esri/mea-central-asia
- http://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- http://main--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/overview
- http://main--esri-eds--esri.aem.live/en-us/capabilities/mapping/smart-mapping
- http://main--esri-eds--esri.aem.live/en-us/digital-twin/overview
- http://main--esri-eds--esri.aem.live/en-us/capabilities/data-management
- http://main--esri-eds--esri.aem.live/en-us/capabilities/field-operations/get-started
- http://main--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
- http://main--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/features/3d-immersive-experiences
- http://main--esri-eds--esri.aem.live/en-us/capabilities/real-time/get-started
- http://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/overview
- http://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- http://main--esri-eds--esri.aem.live/en-us/capabilities/real-time/partners/service
- https://main--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/resources

**Cards block inside Tabs component**
http://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas#esri-events
