### PR TITLE
Media Split Esc Close Modal

### DIFF
--- a/eds/blocks/columns/columns.js
+++ b/eds/blocks/columns/columns.js
@@ -23,9 +23,9 @@ const handleEscKeyPress = (event) => {
   if (event.key === 'Escape') {
     removeModal(document.querySelector('.co3-modal'));
   } else {
-    const iframe = document.querySelector('iframe.co3-modal');
-    if (iframe) {
-      iframe.focus();
+    const co3ModalContainer = document.querySelector('.co3-modal-container');
+    if (co3ModalContainer) {
+      co3ModalContainer.focus();
     }
   }
 };
@@ -38,7 +38,6 @@ function decorateModal() {
   if (videoLink) {
     iframe.setAttribute('src', videoLink.getAttribute('href'));
   }
-
   const modal = document.createElement('div');
   modal.classList.add('co3-modal', 'calcite-mode-dark');
   const closeButton = document.createElement('calcite-icon');
@@ -56,8 +55,10 @@ function decorateModal() {
       removeModal(modal);
     }
   });
+
   const modalContainer = document.createElement('div');
   modalContainer.classList.add('co3-modal-container');
+  modalContainer.setAttribute('tabindex', '0');
   modalContainer.appendChild(iframe);
   modalContainer.appendChild(closeButton);
   modal.appendChild(modalContainer);
@@ -73,6 +74,7 @@ function decorateModal() {
 
   iframe.addEventListener('load', () => {
     toggleLoader();
+    modalContainer.focus();
   });
 }
 
@@ -157,7 +159,8 @@ export default function decorate(block) {
       const playButton = col.querySelector('.play-button');
       if (playButton) {
         playButton.addEventListener('click', (event) => {
-          lastfocusBtn = playButton.parentElement;
+          playButton.setAttribute('tabindex', '0');
+          lastfocusBtn = playButton;
           event.preventDefault();
           toggleLoader();
           decorateModal();

--- a/eds/blocks/columns/columns.js
+++ b/eds/blocks/columns/columns.js
@@ -1,6 +1,6 @@
 import { calciteButton, calciteLink } from '../../scripts/dom-helpers.js';
-let lastfocusBtn;
 
+let lastfocusBtn;
 const toggleLoader = () => {
   const loader = document.querySelector('.web-dev-loader');
   if (loader) {
@@ -28,7 +28,7 @@ const handleEscKeyPress = (event) => {
       iframe.focus();
     }
   }
-}
+};
 
 // decorate modal
 function decorateModal() {

--- a/eds/blocks/columns/columns.js
+++ b/eds/blocks/columns/columns.js
@@ -1,4 +1,5 @@
 import { calciteButton, calciteLink } from '../../scripts/dom-helpers.js';
+let lastfocusBtn;
 
 const toggleLoader = () => {
   const loader = document.querySelector('.web-dev-loader');
@@ -15,7 +16,19 @@ const removeModal = (modal) => {
 
   ['style', 'tabindex', 'aria-hidden'].forEach((attr) => document.body.removeAttribute(attr));
   modal.remove();
+  lastfocusBtn.focus();
 };
+
+const handleEscKeyPress = (event) => {
+  if (event.key === 'Escape') {
+    removeModal(document.querySelector('.co3-modal'));
+  } else {
+    const iframe = document.querySelector('iframe.co3-modal');
+    if (iframe) {
+      iframe.focus();
+    }
+  }
+}
 
 // decorate modal
 function decorateModal() {
@@ -23,8 +36,7 @@ function decorateModal() {
   iframe.classList.add('co3-modal', 'iframe');
   const videoLink = document.querySelector('.video-link');
   if (videoLink) {
-    const href = videoLink.getAttribute('href');
-    iframe.setAttribute('src', href);
+    iframe.setAttribute('src', videoLink.getAttribute('href'));
   }
 
   const modal = document.createElement('div');
@@ -52,6 +64,7 @@ function decorateModal() {
   document.body.setAttribute('tabindex', '-1');
   document.body.setAttribute('aria-hidden', 'true');
   document.body.appendChild(modal);
+  document.addEventListener('keydown', handleEscKeyPress);
   modal.addEventListener('click', (event) => {
     if (event.target === modal) {
       removeModal(modal);
@@ -59,7 +72,6 @@ function decorateModal() {
   });
 
   iframe.addEventListener('load', () => {
-    iframe.focus();
     toggleLoader();
   });
 }
@@ -145,6 +157,7 @@ export default function decorate(block) {
       const playButton = col.querySelector('.play-button');
       if (playButton) {
         playButton.addEventListener('click', (event) => {
+          lastfocusBtn = playButton.parentElement;
           event.preventDefault();
           toggleLoader();
           decorateModal();


### PR DESCRIPTION
Allow "esc" key to close modal

Fix #525 

Test URLs:

- Original: https://www.esri.com/en-us/capabilities/indoor-gis/capabilities/indoor-positioning-navigation
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/indoor-gis/capabilities/indoor-positioning-navigation
- https://mtesc--esri-eds--esri.aem.page/en-us/capabilities/indoor-gis/capabilities/indoor-positioning-navigation

![escModal](https://github.com/user-attachments/assets/6f546c1f-0c54-4fb1-ac51-efa7717103a5)

