### PR TITLE
blockgroup cards

### DIFF
--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -56,8 +56,8 @@ export default function decorate(block) {
   }
   /* change to ul, li */
   const ul = document.createElement('ul');
-  if(block.classList.contains('block-group')){
-    block.classList.add('cardsperrow-' + [...block.children].length);
+  if (block.classList.contains('block-group')) {
+    block.classList.add(`cardsperrow-${[...block.children].length}`);
     block.classList.add('centered');
   }
   [...block.children].forEach((row) => {

--- a/eds/blocks/cards/cards.js
+++ b/eds/blocks/cards/cards.js
@@ -56,6 +56,10 @@ export default function decorate(block) {
   }
   /* change to ul, li */
   const ul = document.createElement('ul');
+  if(block.classList.contains('block-group')){
+    block.classList.add('cardsperrow-' + [...block.children].length);
+    block.classList.add('centered');
+  }
   [...block.children].forEach((row) => {
     const li = document.createElement('li');
     li.classList.add('calcite-animate');
@@ -104,6 +108,7 @@ export default function decorate(block) {
 
     ul.append(li);
   });
+
   ul.querySelectorAll('img').forEach((img) => img.closest('picture')?.replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);


### PR DESCRIPTION
Updated JS to look for blockgroup cards and add cardsperrow-* based on number of li elements.

Fix #517 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/asia-pacific
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific
- After: https://blockgroup--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific
