### PR TITLE
fix(css): replace word-break with overflow-wrap

### DIFF
--- a/eds/blocks/text/text.css
+++ b/eds/blocks/text/text.css
@@ -107,7 +107,7 @@
       margin-block-end: var(--content-spacing);
       margin-inline: auto;
       max-inline-size: 80ch;
-      word-break: break-word;
+      overflow-wrap: break-word;
     }
   }
 


### PR DESCRIPTION
Replaced `word-wrap: break-word;` with `overflow-wrap: break-word;` since it is deprecated.

Fix #530 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://530-text-styelint-error--esri-eds--esri.aem.live/
