### PR TITLE
feat: update Icon path for product icons

### DIFF
--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -270,7 +270,11 @@ function decorateIcon(span, prefix = '', alt = '') {
     .substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
-  img.src = `https://www.esri.com/content/dam/esrisites/en-us/common/icons/meridian-/${prefix}${iconName}.svg`;
+  if (iconName.startsWith('product-')) {
+    img.src = `https://www.esri.com/content/dam/esrisites/en-us/common/icons/product-logos/${prefix}${iconName.substring(8)}.svg`;
+  } else {
+    img.src = `https://www.esri.com/content/dam/esrisites/en-us/common/icons/meridian-/${prefix}${iconName}.svg`;
+  }
   img.alt = alt;
   img.loading = 'lazy';
   span.append(img);

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -312,6 +312,10 @@ main {
     inline-size: 100%;
   }
 
+  .icon img[src*="/product-logos/"] {
+    filter: none;
+  }
+  
   /* arrow right icon ->
     This is the default icon we add for inside redirects
   */


### PR DESCRIPTION
Update scripts to alternate image path for product icons. 

Fix #512

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
- Before: https://main--esri-eds--esri.aem.live/drafts/timw/visualization-interpretation
- After: https://iconpath--esri-eds--esri.aem.live/drafts/timw/visualization-interpretation
