### PR TITLE
fix: format content blocks

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -331,6 +331,13 @@ main {
     padding-inline: var(--space-6);
   }
 
+  .section > .default-content-wrapper * {
+    inline-size: 48vw;
+    margin-block: 3rem;
+    max-inline-size: 720px;
+    padding-inline: 0.5rem;
+  }
+
   .section:where(.center, .centered) > .default-content-wrapper {
     text-align: center;
   }

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -335,7 +335,11 @@ main {
     inline-size: 48vw;
     margin-block: 3rem;
     max-inline-size: 720px;
-    padding-inline: 0.5rem;
+
+    @media screen and (width <= 859px) {
+      inline-size: 100%;
+      max-inline-size: 96vw;
+      }
   }
 
   .section:where(.center, .centered) > .default-content-wrapper {


### PR DESCRIPTION
Formatting for plain content blocks. For Field Operations, top content block just below banner. Other content blocks on page as well. 

Fix #453

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/field-operations/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
- After: https://contentblock--esri-eds--esri.aem.live/en-us/capabilities/field-operations/overview
