### PR TITLE
feat: remove fontweight overrides, bold by default

### DIFF
--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -21,7 +21,6 @@
 
     h3 {
       font-size: var(--title-size);
-      font-weight: 400;
       line-height: 1.375;
       margin-block-end: var(--space-2);
     }

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -136,7 +136,7 @@ main {
   h5,
   h6 {
     font-family: var(--calcite-sans-family);
-    font-weight: var(--calcite-font-weight-normal);
+    font-weight: var(--calcite-font-weight-bold);
     line-height: 1.375;
     margin-block: 0 var(--space-4);
     scroll-margin: calc(var(--nav-height) + 1em);


### PR DESCRIPTION
Update to default to bold for headers. 

Fix #555

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/company
- After: https://boldheaders--esri-eds--esri.aem.live/en-us/about/about-esri/company
