### PR TITLE
feat: update styles to properly center blocks

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -346,6 +346,10 @@ main {
     text-align: center;
   }
 
+  .section:where(.center, .centered) > .default-content-wrapper * {
+    margin-inline: auto;
+  }
+
   .section > div > div {
     background-color: var(--calcite-ui-foreground-1);
     color: var(--calcite-ui-text-1);


### PR DESCRIPTION
Center blocks when class added.

Note: on technology page I updated the class in the metablock for the header/cta

Fix #559

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/technology
- After: https://centerblocks--esri-eds--esri.aem.live/en-us/about/about-esri/technology
