### PR TITLE
fat: banner Nullcheck

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -20,6 +20,10 @@
   padding-block: var(--space-16);
 }
 
+.hero .content:only-child {
+  text-align: center;
+}
+
 .hero h1 {
   font-size: var(--font-6);
   font-weight: var(--calcite-font-weight-bold);

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -3,14 +3,21 @@ import { calciteButton } from '../../scripts/dom-helpers.js';
 import decorateModal from '../../scripts/delayed.js';
 
 export default function decorate(block) {
-  const newChildren = [...block.children].map((entry) => {
-    const entryKey = entry.firstElementChild.textContent.toLowerCase();
+  const newChildren = [...block.children]
+    // filter out empty children
+    .filter((entry) => {
+      const entryContent = entry.lastElementChild;
+      return entryContent.innerHTML !== '' && entryContent.innerHTML !== 'null';
+    })
+    // then map the children to add a class
+    .map((entry) => {
+      const entryKey = entry.firstElementChild.textContent.toLowerCase();
 
-    const entryContent = entry.lastElementChild;
-    entryContent.classList.add(entryKey);
+      const entryContent = entry.lastElementChild;
+      entryContent.classList.add(entryKey);
 
-    return entryContent;
-  });
+      return entryContent;
+    });
   block.replaceChildren(...newChildren);
 
   const imgCollection = block.querySelectorAll('picture > img');
@@ -25,6 +32,12 @@ export default function decorate(block) {
     imgCollection.forEach((img) => {
       img.setAttribute('loading', 'lazy');
     });
+  }
+
+  // look for div.backgroundimage and remove it no images
+  const backgroundImage = block.querySelector('div.backgroundimage');
+  if (backgroundImage && backgroundImage.innerHTML === '<p>null</p>') {
+    backgroundImage.remove();
   }
 
   const blockTitle = block.querySelector('h1');
@@ -57,7 +70,7 @@ export default function decorate(block) {
   const videoLink = block.querySelector('.video-link');
   if (videoLink) {
     const btnContainer = videoLink.closest('.button-container');
-    if ((videoLink) && (btnContainer)) {
+    if (btnContainer) {
       btnContainer.replaceWith(calciteButton({
         'icon-end': 'play-f',
         appearance: 'solid',


### PR DESCRIPTION
Check for any empty containers in hero. 
Remove from dom 
If content is `only-child` center content

Fix #563

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/3d-gis/resources
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/resources
- After: https://nullcheck--esri-eds--esri.aem.live/en-us/capabilities/3d-gis/resources
