### PR TITLE
feat: header sizing

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -6,7 +6,6 @@
 }
 
 .mosaic-reveal-container h2 {
-  /* font-size: calc(100% + 6vw); */
   font-style: normal;
   font-weight: var(--calcite-font-weight-medium);
   line-height: 1.1;
@@ -167,7 +166,6 @@
 
 @media (width >= 1024px) {
   .mosaic-reveal-container h2 {
-    /* font-size: 4.75rem; */
     line-height: 1.11;
   }
 }

--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -6,7 +6,7 @@
 }
 
 .mosaic-reveal-container h2 {
-  font-size: calc(100% + 6vw);
+  /* font-size: calc(100% + 6vw); */
   font-style: normal;
   font-weight: var(--calcite-font-weight-medium);
   line-height: 1.1;
@@ -167,7 +167,7 @@
 
 @media (width >= 1024px) {
   .mosaic-reveal-container h2 {
-    font-size: 4.75rem;
+    /* font-size: 4.75rem; */
     line-height: 1.11;
   }
 }

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -435,6 +435,47 @@ main {
   }
 }
 
+/* Font size classes */
+.font-minus-3 {
+  font-size: var(--font-minus-3);
+}
+
+.font-minus-2 {
+  font-size: var(--font-minus-2);
+}
+
+.font-minus-1 {
+  font-size: var(--font-minus-1);
+}
+
+.font-0 {
+  font-size: var(--font-0);
+}
+
+.font-1 {
+  font-size: var(--font-1);
+}
+
+.font-2 {
+  font-size: var(--font-2);
+}
+
+.font-3 {
+  font-size: var(--font-3);
+}
+
+.font-4 {
+  font-size: var(--font-4);
+}
+
+.font-5 {
+  font-size: var(--font-5);
+}
+
+.font-6 {
+  font-size: var(--font-6)
+}
+
 /* Grid leader trailer spacing */
 .leader-0 {
   margin-block-start: 0;
@@ -604,8 +645,8 @@ body[aria-hidden="true"]{
 }
 
 .default-content-wrapper .iframe-container iframe {
-  inline-size: 100%;
   aspect-ratio: 16 / 9;
+  inline-size: 100%;
   max-inline-size: none;
 }
 

--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -436,44 +436,52 @@ main {
 }
 
 /* Font size classes */
-.font-minus-3 {
+.header-minus-3 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-minus-3);
 }
 
-.font-minus-2 {
+.header-minus-2 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-minus-2);
 }
 
-.font-minus-1 {
+.header-minus-1 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-minus-1);
 }
 
-.font-0 {
+.header-0 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-0);
 }
 
-.font-1 {
+.header-1 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-1);
 }
 
-.font-2 {
+.header-2 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-2);
 }
 
-.font-3 {
+.header-3 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-3);
 }
 
-.font-4 {
+.header-4 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-4);
 }
 
-.font-5 {
+.header-5 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
   font-size: var(--font-5);
 }
 
-.font-6 {
-  font-size: var(--font-6)
+.header-6 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
+  font-size: var(--font-6);
+}
+
+.header-7 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
+  font-size: var(--font-7);
+}
+
+.header-8 > .default-content-wrapper > :where(h1, h2, h3, h4, h5, h6) {
+  font-size: var(--font-8);
 }
 
 /* Grid leader trailer spacing */


### PR DESCRIPTION
Removing component-specific header sizing from Mosaic reveal for the left side. The left content is auto section, not block section. 
Adding `header-X` sizing classes. 
Allows authors to size headers in auto section content. Prefer over hard coded sizes. 

Fix #586 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/locations
- Before: https://main--esri-eds--esri.aem.live/drafts/timw/locations
- After: https://sizing--esri-eds--esri.aem.live/drafts/timw/locations
