### PR TITLE
fix: page width overflow

### DIFF
--- a/eds/blocks/media-gallery/media-gallery.css
+++ b/eds/blocks/media-gallery/media-gallery.css
@@ -1,7 +1,3 @@
-/* .media-gallery-wrapper {
-  inline-size: 100vw;
-} */
-
 .media-gallery {
   ul {
     display: grid;

--- a/eds/blocks/media-gallery/media-gallery.css
+++ b/eds/blocks/media-gallery/media-gallery.css
@@ -1,6 +1,6 @@
-.media-gallery-wrapper {
+/* .media-gallery-wrapper {
   inline-size: 100vw;
-}
+} */
 
 .media-gallery {
   ul {

--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -63,7 +63,6 @@
 .tabs .tab-component {
   display: flex;
   flex-direction: column;
-  inline-size: 100vw;
   justify-content: flex-end;
 }
 
@@ -145,8 +144,6 @@
 
 .tabs .tab-content > .grid-container {
   display: block;
-  inline-size: 100vw;
-  padding: 0;
   position: relative;
 }
 


### PR DESCRIPTION
Some unneccessary `inline-size: 100vw`. Blocks do that by default. In this case actually causing some blocks to be too wide. 

Fix #554

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://width--esri-eds--esri.aem.live/en-us/about/about-esri/overview
