### PR TITLE
Mosaic Reveal Overlay Update

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -59,7 +59,7 @@
 
 .mosaic-reveal .mosaic-reveal-content {
   align-items: center;
-  background-color: var(--calcite-ui-foreground-1);
+  background-color: var(--calcite-ui-foreground-2);
   block-size: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Change color theme to calcite-mode-light to test light overlay.

Fix #583

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://mrOverlay--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
