### PR TITLE
Media Gallery Dark Overlay

### DIFF
--- a/eds/blocks/media-gallery/media-gallery.css
+++ b/eds/blocks/media-gallery/media-gallery.css
@@ -28,7 +28,7 @@
     --gradient-angle-m: to top;
     --gradient-transition: 60%;
 
-    background: linear-gradient(to top, var(--esri-ui-opacity80-inverse), transparent 60%);
+    background: linear-gradient(to top, var(--esri-ui-opacity80), transparent 80%);
     block-size: 100%;
     content: "";
     inline-size: 100%;


### PR DESCRIPTION
Update overlay from light to a dark overlay

Fix #583 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://mgOverlay--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- 
![overlay-jpg-2043×374--02-20-2025_08_28_AM](https://github.com/user-attachments/assets/771bde18-ab71-4390-906c-44b282cce51e)
