### PR TITLE
Allow table alignment to be reflected in the page

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -111,6 +111,16 @@
   box-sizing: border-box;
 }
 
+/* Horizontal alignment */
+[data-align="left"] { text-align: start }
+[data-align="center"] { text-align: center }
+[data-align="right"] { text-align: end }
+
+/* Vertical alignment */
+[data-valign="top"] { align-self: flex-start }
+[data-valign="middle"] { align-self: center }
+[data-valign="bottom"] { align-self: flex-end }
+
 body {
   background-color: var(--calcite-ui-foreground-1);
   color: var(--calcite-ui-text-1);
@@ -317,7 +327,7 @@ main {
   .icon img[src*="/product-logos/"] {
     filter: none;
   }
-  
+
   .default-arrow-right {
     margin-inline-start: 4px;
   }
@@ -604,8 +614,8 @@ body[aria-hidden="true"]{
 }
 
 .default-content-wrapper .iframe-container iframe {
-  inline-size: 100%;
   aspect-ratio: 16 / 9;
+  inline-size: 100%;
   max-inline-size: none;
 }
 


### PR DESCRIPTION
This PR allows alignment within tables (blocks) to be reflected via css (they're already reflected as data attributes).
<img width="961" alt="image" src="https://github.com/user-attachments/assets/d6f2a3b5-70d3-4ca8-9d53-cc9f13b926a0" />

<img width="842" alt="image" src="https://github.com/user-attachments/assets/cc43f4e9-da19-4357-bafa-072c5494a2c4" />

Test URLs:
- Before: https://main--esri-eds--esri.aem.live/drafts/acarol/overview
- After: https://<branch>--esri-eds--esri.aem.live/drafts/acarol/overview
