### PR TITLE
CTA button that opens oneform modal

### DIFF
--- a/eds/blocks/call-to-action/call-to-action.css
+++ b/eds/blocks/call-to-action/call-to-action.css
@@ -30,11 +30,31 @@
   padding: var(--space-24) 0 var(--space-32);
 }
 
-.section.form-container.call-to-action-container > .default-content-wrapper {
+.section.call-to-action-container .default-content-wrapper {
+  inline-size: 1440px;
+  margin: auto;
+  max-inline-size: 632px;
   padding-block-end: 0;
+  text-align: center;
+
+  & > :where(h2, p) {
+    inline-size: 100%;
+    margin: 0 auto;
+  }
+
+  & > h2 {
+    margin-block-end: var(--space-2);
+  }
+
+  & > h2 + p {
+    color: var(--calcite-ui-text-2);
+    font-size: var(--font-2);
+  }
 }
 
-.section.form-container.call-to-action-container > .form-wrapper .form.card-modal.button {
+.section.call-to-action-container .form-wrapper .form.card-modal.button {
+  margin-block-start: var(--space-4);
+
   .cards.simple {
     padding: 0;
   }
@@ -50,6 +70,7 @@
   }
 
   .card-body-content {
+    cursor: pointer;
     padding: 0;
   }
 
@@ -110,7 +131,8 @@ p.button-container .button {
   display: flex;
 
   h2 {
-    font-size: var(--font-0);
+    font-size: var(--font-4);
+    font-weight: var(--calcite-font-weight-bold);
   }
 
   /* if it has three or more children, */
@@ -197,7 +219,6 @@ p.button-container .button {
       filter: var(--image-icon-filter);
     }
   }
-}
 
 @media (width <= 1440px) {
   .call-to-action.fragment .cards.questions {
@@ -250,4 +271,5 @@ p.button-container .button {
   .call-to-action > div > div:last-child {
     border-block-end: none;
   }
+}
 }


### PR DESCRIPTION
Restructured the CTA button that opens a oneform modal.

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/imagery-remote-sensing/resources
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/resources
- After: https://ctabutton--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/resources


- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://ctabutton--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
