### PR TITLE
Image Switcher use hidden property

### DIFF
--- a/eds/blocks/image-switcher/image-switcher.css
+++ b/eds/blocks/image-switcher/image-switcher.css
@@ -89,10 +89,6 @@
     position: relative;
   }
 
-  & > div[aria-hidden="true"] {
-    display: none;
-  }
-
   .image-div {
     block-size: 100%;
     inline-size: 100%;
@@ -223,3 +219,4 @@
     }
   }
 }
+

--- a/eds/blocks/image-switcher/image-switcher.js
+++ b/eds/blocks/image-switcher/image-switcher.js
@@ -20,10 +20,10 @@ export default function decorate(block) {
 
   let selectedIndex = 0;
   const changeSelectedTab = (index) => {
-    tabs[selectedIndex].setAttribute('aria-hidden', 'true');
+    tabs[selectedIndex].setAttribute('hidden', '');
     navList.children[selectedIndex].classList.remove('active');
     navList.children[index].classList.add('active');
-    tabs[index].setAttribute('aria-hidden', 'false');
+    tabs[index].removeAttribute('hidden');
     selectedIndex = index;
   };
 
@@ -78,7 +78,7 @@ export default function decorate(block) {
     const link = domEl('calcite-link', { href: url, 'icon-end': 'arrow-right' }, title);
     buttonContainer?.parentElement.replaceChild(link, buttonContainer);
 
-    tab.setAttribute('aria-hidden', 'true');
+    tab.setAttribute('hidden', '');
     tab.setAttribute('role', 'tabpanel');
   });
 


### PR DESCRIPTION
Switch from 'aria-hidden' to 'hidden' property. 
Fix #590 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
- After: https://switchHidden--esri-eds--esri.aem.live/en-us/capabilities/imagery-remote-sensing/capabilities/visualization-interpretation
