### PR TITLE
Mosaic Reveal switch to hidden attribute

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -99,7 +99,7 @@
   text-decoration: underline;
 }
 
-.mosaic-reveal .mosaic-reveal-content[aria-hidden="true"] {
+.mosaic-reveal .mosaic-reveal-content[hidden] {
   block-size: 0;
   opacity: 0;
   pointer-events: none;

--- a/eds/blocks/mosaic-reveal/mosaic-reveal.js
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.js
@@ -17,7 +17,7 @@ export default function decorate(block) {
   const contents = [...block.children].map((child) => child.children[1]);
   contents.forEach((content) => {
     content.classList.add('mosaic-reveal-content');
-    content.setAttribute('aria-hidden', 'true');
+    content.setAttribute('hidden', '');
 
     const anchorElem = content.querySelector('a');
     const linkText = anchorElem.textContent;
@@ -31,9 +31,9 @@ export default function decorate(block) {
     anchorElem.parentElement.removeChild(anchorElem);
   });
 
-  const revealContent = div({ class: 'mosaic-reveal-content', 'aria-hidden': 'true' });
+  const revealContent = div({ class: 'mosaic-reveal-content', 'hidden': 'true' });
   revealContent.addEventListener('click', () => {
-    revealContent.setAttribute('aria-hidden', 'true');
+    revealContent.setAttribute('hidden', '');
   });
 
   const mediaQuery = window.matchMedia('(width < 860px)');
@@ -41,10 +41,10 @@ export default function decorate(block) {
   mediaQuery.onchange = (e) => {
     if (e.matches) {
       contents.forEach((content) => {
-        content.setAttribute('aria-hidden', 'true');
+        content.setAttribute('hidden', '');
       });
     } else {
-      revealContent.setAttribute('aria-hidden', 'true');
+      revealContent.setAttribute('hidden', '');
     }
   };
 
@@ -53,7 +53,7 @@ export default function decorate(block) {
     const mosaicTitle = msrevealcontent.querySelector('h3');
     child.addEventListener('click', () => {
       if (mediaQuery.matches) {
-        revealContent.setAttribute('aria-hidden', 'false');
+        revealContent.removeAttribute('hidden');
         const children = [...contents[idx].children].map((el) => el.cloneNode(true));
         revealContent.replaceChildren(...children);
       }
@@ -61,7 +61,7 @@ export default function decorate(block) {
 
     child.addEventListener('mouseenter', () => {
       if (!mediaQuery.matches) {
-        child.querySelector('.mosaic-reveal-content').ariaHidden = false;
+        child.querySelector('.mosaic-reveal-content').removeAttribute('hidden');
         mosaicTitle.setAttribute('tabindex', '0');
         setTimeout(() => {
           mosaicTitle.focus();
@@ -71,7 +71,7 @@ export default function decorate(block) {
 
     child.addEventListener('mouseleave', () => {
       if (!mediaQuery.matches) {
-        child.querySelector('.mosaic-reveal-content').ariaHidden = true;
+        child.querySelector('.mosaic-reveal-content').setAttribute('hidden','true') ;
         mosaicTitle.setAttribute('tabindex', '-1');
       }
     });

--- a/eds/blocks/mosaic-reveal/mosaic-reveal.js
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.js
@@ -31,7 +31,7 @@ export default function decorate(block) {
     anchorElem.parentElement.removeChild(anchorElem);
   });
 
-  const revealContent = div({ class: 'mosaic-reveal-content', 'hidden': 'true' });
+  const revealContent = div({ class: 'mosaic-reveal-content', hidden: '' });
   revealContent.addEventListener('click', () => {
     revealContent.setAttribute('hidden', '');
   });
@@ -71,7 +71,7 @@ export default function decorate(block) {
 
     child.addEventListener('mouseleave', () => {
       if (!mediaQuery.matches) {
-        child.querySelector('.mosaic-reveal-content').setAttribute('hidden','true') ;
+        child.querySelector('.mosaic-reveal-content').setAttribute('hidden', 'true');
         mosaicTitle.setAttribute('tabindex', '-1');
       }
     });

--- a/eds/blocks/mosaic-reveal/mosaic-reveal.js
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.js
@@ -71,7 +71,7 @@ export default function decorate(block) {
 
     child.addEventListener('mouseleave', () => {
       if (!mediaQuery.matches) {
-        child.querySelector('.mosaic-reveal-content').setAttribute('hidden', 'true');
+        child.querySelector('.mosaic-reveal-content').setAttribute('hidden', '');
         mosaicTitle.setAttribute('tabindex', '-1');
       }
     });


### PR DESCRIPTION
Switch from 'aria-hidden' to 'hidden' property.

Fix #602 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/locations
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/locations
- After: https://mrHidden--esri-eds--esri.aem.live/en-us/about/about-esri/locations

![Screenshot-2025-02-24-at-1-58-07-PM-png-793×782--02-24-2025_02_04_PM](https://github.com/user-attachments/assets/ea6c3c93-f111-4564-a308-769a77fc1170)
