### PR TITLE
feat(ecs): Remove hard coded image

### DIFF
--- a/eds/blocks/elastic-content-strip/elastic-content-strip.css
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.css
@@ -40,7 +40,6 @@
 }
 
 .elastic-content-strip.block > div {
-  background-image: url("/assets/location-overview-programs-background.jpeg");
   background-position: center;
   background-size: cover;
   color: var(--calcite-ui-text-1);

--- a/eds/blocks/elastic-content-strip/elastic-content-strip.js
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.js
@@ -7,7 +7,9 @@ import {
 
 export default function decorate(block) {
   block.querySelectorAll('.elastic-content-strip > div > div').forEach((div) => {
-    const linkHref = div.querySelector('a,calcite-button').href;
+    const linkElement = div.querySelector('a,calcite-button');
+    if (!linkElement) return;
+    const linkHref = linkElement.href;
 
     const elasticContentWrapper = a({
       class: 'elastic-content-link-wrapper',
@@ -17,8 +19,20 @@ export default function decorate(block) {
     elasticContentWrapper.appendChild(div);
     decorateInnerHrefButtonsWithArrowIcon(elasticContentWrapper);
 
+    const backgroundImage = div.querySelector('picture');
+    if (backgroundImage) {
+      const backgroundImageSrc = backgroundImage
+        .querySelector('source')
+        .srcset
+      div.parentNode.parentNode.style.backgroundImage = `url(${backgroundImageSrc})`;
+    }
+    backgroundImage.remove();
+
     const btn = div.querySelector('.button-container');
-    const labelText = btn.querySelector('a').textContent;
+    if (!btn) return;
+    const labelElement = btn.querySelector('a');
+    if (!labelElement) return;
+    const labelText = labelElement.textContent;
     const btnLink = calciteLink({
       'icon-end': 'arrowRight',
       class: 'button link',

--- a/eds/blocks/elastic-content-strip/elastic-content-strip.js
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.js
@@ -23,7 +23,7 @@ export default function decorate(block) {
     if (backgroundImage) {
       const backgroundImageSrc = backgroundImage
         .querySelector('source')
-        .srcset
+        .srcset;
       div.parentNode.parentNode.style.backgroundImage = `url(${backgroundImageSrc})`;
     }
     backgroundImage.remove();


### PR DESCRIPTION
Background image is optional. 
Remove hard-coded from CSS. 
Allow for image to be authored

https://esriis.sharepoint.com/:w:/r/sites/EsriMarketingPublic/_layouts/15/Doc.aspx?sourcedoc=%7BD87725CE-47CA-4364-8392-881DDAE2C32C%7D&file=resources.docx&action=default&mobileredirect=true

Fix #412

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/drafts/timw/resources
- After: https://ecsimage--esri-eds--esri.aem.live/drafts/timw/resources
