### PR TITLE
Modal Close Button Max Size

### DIFF
--- a/eds/styles/styles.css
+++ b/eds/styles/styles.css
@@ -652,8 +652,8 @@ body[aria-hidden="true"]{
   inline-size: 85%;
   inset-block-start: 50%;
   inset-inline-start: 50%;
-  position: absolute;
   max-inline-size: 950px;
+  position: absolute;
   transform: translate(-50%, -50%);
 }
 


### PR DESCRIPTION
Confirm modal close button is always visible no matter the width of the viewport. 

Fix #622 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://modalCls--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- 
![About-Esri-The-Science-of-Where-03-06-2025_09_10_AM-jpg-1332×758--03-06-2025_09_12_AM](https://github.com/user-attachments/assets/c3bb4339-6fd7-4536-9f80-6eb05cf0291b)
