### PR TITLE
Elastic Content Strip Console Error 

### DIFF
--- a/eds/blocks/elastic-content-strip/elastic-content-strip.js
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.js
@@ -25,8 +25,8 @@ export default function decorate(block) {
         .querySelector('source')
         .srcset;
       div.parentNode.parentNode.style.backgroundImage = `url(${backgroundImageSrc})`;
+      backgroundImage.remove();
     }
-    backgroundImage.remove();
 
     const btn = div.querySelector('.button-container');
     if (!btn) return;


### PR DESCRIPTION
Check for elastic.js console error occurs if background image is not authored.

failed to load module for elastic-content-strip TypeError: Cannot read properties of null (reading 'remove')
at elastic-content-strip.js:29:21
at NodeList.forEach ()
at Module.decorate (elastic-content-strip.js:9:64)
at aem.js:605:32

Fix #621 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/real-time/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/real-time/overview
- After: https://elasticErr--esri-eds--esri.aem.live/en-us/capabilities/real-time/overview
