### PR TITLE
CTA Content Off Center

### DIFF
--- a/eds/blocks/call-to-action/call-to-action.css
+++ b/eds/blocks/call-to-action/call-to-action.css
@@ -31,10 +31,7 @@
 }
 
 .section.call-to-action-container .default-content-wrapper {
-  inline-size: 1440px;
-  margin: auto;
   max-inline-size: 632px;
-  padding-block-end: 0;
   text-align: center;
 
   & > :where(h2, p) {


### PR DESCRIPTION
CTA content off center on MOBILE view. 

![off-center](https://github.com/user-attachments/assets/d0b9f334-4964-46c1-90f6-8f240f0886f0)



Fix #632 

Test URLs:
- Original: https://www.esri.com/en-us/capabilities/real-time/features/visualization
- Before: https://main--esri-eds--esri.aem.live/en-us/capabilities/real-time/features/visualization
- After: https://ctaMobile--esri-eds--esri.aem.live/en-us/capabilities/real-time/features/visualization
