### PR TITLE
feat(sidekick): Add assets to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -4,8 +4,13 @@
       {
         "id": "asset-library",
         "title": "Asset Library",
-        "environments": ["edit"]
-      }
+        "environments": ["edit"],
+        "url": "/tools/sidekick/asset-library.html",
+        "isPalette": true,
+        "includePaths": ["**.docx**"],
+        "passConfig": true,
+        "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
+      },
       {
         "id": "library",
         "title": "Library",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -2,6 +2,11 @@
     "project": "esri",
     "plugins": [
       {
+        "id": "asset-library",
+        "title": "Asset Library",
+        "environments": ["edit"]
+      }
+      {
         "id": "library",
         "title": "Library",
         "environments": ["edit"],

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,11 +3,15 @@
     "plugins": [
       {
         "id": "asset-library",
-        "title": "Asset Library",
-        "environments": ["edit"],
+        "title": "Assets",
+        "environments": [
+            "edit"
+        ],
         "url": "https://experience.adobe.com/solutions/CQ-helix-assets-addon/static-assets/resources/asset-selector.html",
         "isPalette": true,
-        "includePaths": ["**.docx**"],
+        "includePaths": [
+            "**.docx**"
+        ],
         "passConfig": true,
         "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
       },

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -5,7 +5,7 @@
         "id": "asset-library",
         "title": "Asset Library",
         "environments": ["edit"],
-        "url": "/tools/sidekick/asset-library.html",
+        "url": "https://experience.adobe.com/solutions/CQ-helix-assets-addon/static-assets/resources/asset-selector.html",
         "isPalette": true,
         "includePaths": ["**.docx**"],
         "passConfig": true,

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -4,14 +4,10 @@
       {
         "id": "asset-library",
         "title": "Assets",
-        "environments": [
-            "edit"
-        ],
+        "environments": ["edit"],
         "url": "https://experience.adobe.com/solutions/CQ-helix-assets-addon/static-assets/resources/asset-selector.html",
         "isPalette": true,
-        "includePaths": [
-            "**.docx**"
-        ],
+        "includePaths": ["**.docx**"],
         "passConfig": true,
         "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
       },


### PR DESCRIPTION
Configure sidekick per documents 
https://www.aem.live/developer/configuring-aem-assets-sidekick-plugin

Fix #634

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://assets--esri-eds--esri.aem.live/en-us/about/about-esri/overview
