### PR TITLE
fix(ui): media gallery overlay color update

### DIFF
--- a/eds/blocks/media-gallery/media-gallery.css
+++ b/eds/blocks/media-gallery/media-gallery.css
@@ -24,7 +24,7 @@
     --gradient-angle-m: to top;
     --gradient-transition: 60%;
 
-    background: linear-gradient(to top, var(--esri-ui-opacity80), transparent 80%);
+    background: linear-gradient(to top, var(--esri-ui-opacity80-inverse), transparent 80%);
     block-size: 100%;
     content: "";
     inline-size: 100%;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

- Updated bg overlay color to match the prod.
- Calcite mode effects the overlay color.


Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://mgoverlaycolor--esri-eds--esri.aem.live/en-us/about/about-esri/overview

Calcite mode is not matching with the prod so as the overlay gradient. Calcite mode should be updated to dark.
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://mgoverlaycolor--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
