### PR TITLE
Add a new attribute for mg card overlay color control

### DIFF
--- a/eds/blocks/media-gallery/media-gallery.css
+++ b/eds/blocks/media-gallery/media-gallery.css
@@ -1,4 +1,10 @@
 .media-gallery {
+  &.mg-card-dark {
+    picture::after {
+      background: linear-gradient(to top, var(--esri-ui-opacity80), transparent 80%);
+    }
+  }
+
   ul {
     display: grid;
     grid-gap: 1rem;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
- Added a new attribute to control the mg card overlay color.
- Added 'mg-card-dark' to add dark overlay for mg card irrespective of calcite mode.

Test URLs 1:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://mgcardcolor--esri-eds--esri.aem.live/en-us/about/about-esri/overview

Test URLs 2:
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://mgcardcolor--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
