### PR TITLE
fix(ui): Fix for the alignment of image inside tabs content

### DIFF
--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -246,6 +246,7 @@
     }
 
     .tab-content p:last-child picture {
+      block-size: 100%;
       inline-size: 100%;
     }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #645 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://tabsimage--esri-eds--esri.aem.live/en-us/about/about-esri/overview
