### PR TITLE
fix(ui): fix for hero bg video on large devices[#652]

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -63,7 +63,9 @@
 
 .hero video {
   block-size: 100%;
+  inline-size: 100%;
   inset: 0;
+  object-fit: cover;
   z-index: -2;
 }
 


### PR DESCRIPTION
Fixed video size to take the full width of screen size on large devices.

Fix #652 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://herovideo--esri-eds--esri.aem.live/en-us/about/about-esri/overview
