### PR TITLE
fix(ui): media split tab panel font size[#650]

### DIFF
--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -45,7 +45,6 @@
   font-weight: 600;
   margin: 0;
   margin-block-end: 0.5rem;
-  text-transform: uppercase;
 }
 
 .tabs .text-wrapper p:last-child {
@@ -55,7 +54,7 @@
 }
 
 .tabs .text-wrapper h2 {
-  font-size: var(--font-8);
+  font-size: var(--font-6);
   margin: 0;
   margin-block-end: 0.6rem;
 }


### PR DESCRIPTION
Font size is updated for media split inside tab panel
Fix #650 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://mediasplittab--esri-eds--esri.aem.live/en-us/about/about-esri/overview
