### PR TITLE
fix(ui): story teller font size update[#649]

### DIFF
--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -47,7 +47,7 @@
   }
 
   h2 {
-    font-size: var(--font-5);
+    font-size: var(--font-4);
     font-weight: var(--calcite-font-weight-bold);
   }
 

--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -52,7 +52,7 @@
   }
 
   p {
-    font-size: var(--font-1);
+    font-size: var(--font-0);
   }
 
   img, video {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #649 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://storytellerfont--esri-eds--esri.aem.live/en-us/about/about-esri/overview
