### PR TITLE
Story teller spacing updates[#648]

### DIFF
--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -15,8 +15,13 @@
     flex-direction: column;
 
     .content {
-      margin-inline-end: unset;
-      margin-inline-start: auto;
+      @media screen and (width >= 1152px) {
+        inline-size: 50%;
+        margin-inline: auto 0;
+        max-inline-size: 720px;
+        padding: 0;
+        padding-inline-end: var(--space-24);
+      }
     }
 
     .media {
@@ -38,7 +43,7 @@
 
   @media screen and (width >= 1152px) {
     flex-direction: row;
-    gap: var(--space-16);
+    gap: 0;
     min-block-size: 1100px;
 
     &:has(.content:first-child) {
@@ -70,8 +75,12 @@
     padding-inline: var(--space-6);
 
     @media screen and (width >= 1152px) {
-      inline-size: min(50%, 640px);
-      padding-inline: var(--space-16);
+      inline-size: min(50%, 720px);
+      inline-size: 50%;
+      margin-inline-end: auto;
+      max-inline-size: 720px;
+      padding-inline: var(--space-20) 0;
+      padding-inline-end: 14px;
     }
   }
 


### PR DESCRIPTION
Updated spacing for story teller to match with prod.

Fix #648 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://storytellerspacing--esri-eds--esri.aem.live/en-us/about/about-esri/overview
