### PR TITLE
Updated map container height(#657)

### DIFF
--- a/eds/blocks/map/map.css
+++ b/eds/blocks/map/map.css
@@ -96,6 +96,10 @@
   padding: 1rem;
 }
 
+.map .frame-wrapper {
+  block-size: 785px;
+}
+
 /* Fullscreen mode */
 .frame-wrapper.is-fullscreen {
   block-size: 100%;

--- a/eds/blocks/map/map.css
+++ b/eds/blocks/map/map.css
@@ -96,10 +96,6 @@
   padding: 1rem;
 }
 
-.map .frame-wrapper {
-  block-size: 785px;
-}
-
 /* Fullscreen mode */
 .frame-wrapper.is-fullscreen {
   block-size: 100%;

--- a/eds/blocks/map/map.css
+++ b/eds/blocks/map/map.css
@@ -132,6 +132,7 @@
   }
 
   .frame-wrapper {
+    aspect-ratio: 1/1;
     max-inline-size: 96vw;
   }
 }
@@ -143,6 +144,7 @@
   }
 
   .frame-wrapper {
+    aspect-ratio: 4/3;
     inline-size: 72vw;
     max-inline-size: 1080px;
   }
@@ -163,7 +165,7 @@
 /* Smaller screens - more square aspect ratio */
 @media (width < 480px) {
   .frame-wrapper {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 1 / 2;
   }
 }
 


### PR DESCRIPTION
Updated map height to match with prod.

Fix #657 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://mapheight--esri-eds--esri.aem.live/en-us/about/about-esri/americas
