### PR TITLE
updated cards block spacing on the top[#651]

### DIFF
--- a/eds/blocks/cards/cards.css
+++ b/eds/blocks/cards/cards.css
@@ -10,7 +10,6 @@
 .cards {
   background-color: var(--calcite-ui-foreground-1);
   color: var(--calcite-ui-text-1);
-  padding: 4rem 0;
 }
 
 .cards .icon img {


### PR DESCRIPTION
Removed spacing on the top for cards block.

Fix #651 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://cardsspacing--esri-eds--esri.aem.live/en-us/about/about-esri/overview