### PR TITLE
banner title alignment[#647]

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -127,12 +127,12 @@
   }
 
   .hero .content {
-    padding-inline-start: 2vw;
+    padding-inline-start: 0;
   }
 
   .hero :is(.image, .content) {
     inline-size: 50%;
-    max-inline-size: 700px;
+    max-inline-size: 720px;
   }
 
   .hero :where(h1, p) {


### PR DESCRIPTION
- Spacign and max inline size is updated for banner title.
- Tested on all viewports to match with prod.
- On desktop its aligned with global and secondary nav.
- On tablet and mobile, spacing on the left matches with prod but does not align with secondary nav
- Secondary nav alignment should be adjusted to match with prod

Fix #647 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://bannertitle--esri-eds--esri.aem.live/
