### PR TITLE
fix for cta spacing and alignment

### DIFF
--- a/eds/blocks/call-to-action/call-to-action.css
+++ b/eds/blocks/call-to-action/call-to-action.css
@@ -27,7 +27,7 @@
   background: var(--calcite-ui-foreground-1);
   color: var(--calcite-ui-text-1);
   justify-content: center;
-  padding: 0 0 var(--space-32) 0;
+  padding: var(--space-24) 0 var(--space-32) 0;
 }
 
 .section.call-to-action-container .default-content-wrapper {
@@ -92,7 +92,6 @@
 
   > div {
     display: flex;
-    flex-direction: column;
     inline-size: 100%;
 
     > div {

--- a/eds/blocks/call-to-action/call-to-action.css
+++ b/eds/blocks/call-to-action/call-to-action.css
@@ -105,6 +105,7 @@
       margin-inline-end: -0.01rem;
 
       &:last-child {
+        border-block-end: none;
         border-inline-end: none;
         margin-inline-end: 0;
       }
@@ -116,6 +117,31 @@
     font-weight: var(--calcite-font-weight-normal);
   }
 }
+
+@media (width <= 768px) {
+  .call-to-action > div {
+    align-items: center;
+    flex-direction: column;
+  }
+
+  .call-to-action > div > div {
+    border-block-end: 0.01rem solid var(--calcite-ui-border-1);
+    border-inline-end: none;
+    inline-size: 100%;
+    margin-block: 0;
+    margin-inline-end: 0;
+  }
+
+  .call-to-action > div > div .button-container {
+    margin-block-end: var(--space-10);
+  }
+
+  .call-to-action > div > div:last-child {
+    border-block-end: none;
+    margin-block: var(--space-10);
+  }
+}
+
 
 p.button-container .button {
   margin-block-start: 0;
@@ -354,25 +380,8 @@ p.button-container .button {
   .call-to-action.fragment .cards.questions > ul:has(li:nth-child(1):last-child) li {
     --cards-per-row: 1;
   }
+
+
 }
 
-
-@media (width <= 768px) {
-  .call-to-action > div {
-    align-items: center;
-    flex-direction: column;
-  }
-
-  .call-to-action > div > div {
-    border-block-end: 0.01rem solid var(--calcite-ui-border-1);
-    border-inline-end: none;
-    inline-size: 100%;
-    margin-block: var(--space-10);
-    margin-inline-end: 0;
-  }
-
-  .call-to-action > div > div:last-child {
-    border-block-end: none;
-  }
-}
 }


### PR DESCRIPTION
Updated cta block to align horizontally and adjusted top and bottom spacing

Fix #664

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://ctaspacing--esri-eds--esri.aem.live/en-us/about/about-esri/overview
