### PR TITLE
fix(ui): tab title hover state styling update[#667]

### DIFF
--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -122,6 +122,10 @@
   padding: 1rem;
 }
 
+.tabs .tab-nav .tab-title button:is(:hover, :focus, :active) {
+  box-shadow: none;
+}
+
 .tabs .tab-nav .tab-title .icon {
   margin-block-end: var(--space-4);
 }
@@ -204,10 +208,7 @@
         padding: 1rem;
       }
 
-      .tab-title[aria-selected="false"]:hover {
-        border-block-end: 3px solid #0079c180;
-      }
-
+      .tab-title[aria-selected="false"]:hover, 
       .tab-title[aria-selected="true"] {
         border-block-end: 3px solid var(--calcite-ui-brand);
       }


### PR DESCRIPTION
- Removed box shadow for hover state of tab title.
- Updated the hover state underline color to match with prod.

Fix #667 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://tabtitle--esri-eds--esri.aem.live/en-us/about/about-esri/overview
