### PR TITLE
ECS title font weight[#682]

### DIFF
--- a/eds/blocks/elastic-content-strip/elastic-content-strip.css
+++ b/eds/blocks/elastic-content-strip/elastic-content-strip.css
@@ -29,7 +29,7 @@
 .elastic-content-strip.block h2 {
   color: var(--calcite-ui-text-1);
   font-size: var(--font-3);
-  font-weight: var(--calcite-font-weight-normal);
+  font-weight: var(--calcite-font-weight-bold);
   margin-block: var(--space-8);
 }
 


### PR DESCRIPTION
Font weight of ECS title is updated to bold to match with prod.

Fix #682 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://ecstitle--esri-eds--esri.aem.live/en-us/about/about-esri/americas
