### PR TITLE
fix(ui): updated font size for mosaic reveal[#691]

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -168,8 +168,9 @@
 
 @media (width >= 1024px) {
   .mosaic-reveal-container h2 {
-    font-size: 4.75rem;
-    line-height: 1.11;
+    font-size: var(--font-4);
+    font-weight: var(--calcite-font-weight-bold);
+    line-height: 1.5;
   }
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #691 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
- After: https://msfont--esri-eds--esri.aem.live/en-us/about/about-esri/europe/overview
