### PR TITLE
fix(ui): update calcite buttons on dark mode pages

### DIFF
--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -53,6 +53,7 @@ function decorateButtons(block) {
     const linkButton = calciteButton({
       'aria-label': anchorElement.innerHTML,
       tabindex: '0',
+      'icon-end': 'arrowRight',
       href: anchorElement.getAttribute('href'),
       scale: anchorElement.getAttribute('scale') || 'l',
     });

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -211,6 +211,16 @@ function decorateMode(element) {
     }
   });
 }
+// If the main element has the calcite-mode-dark class, set all calcite buttons to inverse(black and white))
+window.addEventListener('load', () => {
+  const main = document.querySelector('main');
+  if (main && main.classList.contains('calcite-mode-dark')) {
+    const calciteButtons = document.querySelectorAll('calcite-button');
+    calciteButtons.forEach((button) => {
+      button.setAttribute('kind', 'inverse');
+    });
+  }
+});
 
 export function decorateBlockMode(block) {
   decorateMode(block);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #690 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://calcitebutton--esri-eds--esri.aem.live/en-us/about/about-esri/overview
