### PR TITLE
fix(ui): story teller loop video[#663]

### DIFF
--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -117,15 +117,12 @@ function setupVideoControl(playButtonElement, videoElement, videoLength) {
         playVideo(videoElement); // Play the video again
       }
       requestAnimationFrame(updateDashOffset);
-    } else {
+    } else if (currentTime >= totalFrames) {
       // Check if the video has ended, reset dash offset and play again
-      if (currentTime >= totalFrames) {
-        progressCircle.style.strokeDashoffset = totalFrames;
-      } else {
+      progressCircle.style.strokeDashoffset = totalFrames;
+    } else {
       // Schedule the next update for smoother animation
-        requestAnimationFrame(updateDashOffset);
-      }
-      // No operation to ensure the else block is not empty
+      requestAnimationFrame(updateDashOffset);
     }
     if (currentTime === totalFrames) {
       progressCircle.style.strokeDashoffset = totalFrames;


### PR DESCRIPTION
Added 'loop-video' class for the storyteller instance with title 'Embracing a geographic approach'

Fix #663 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://stloop--esri-eds--esri.aem.live/en-us/about/about-esri/overview

<img width="652" alt="Screenshot 2025-06-12 at 3 43 34 PM" src="https://github.com/user-attachments/assets/e6fdf3c5-66de-4706-b14a-1c40481cdd8c" />

