### PR TITLE
Mosaic Reveal remove box shadow

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -47,6 +47,7 @@
   margin: 0;
   padding: 0;
   position: absolute;
+  box-shadow: none;
 }
 
 .mosaic-reveal calcite-icon {


### PR DESCRIPTION
Remove box shadow on hover.

![Screenshot-at-AM-png-×--06-12-2025_10_16_AM](https://github.com/user-attachments/assets/09549ce3-db6b-4313-8cb7-579a2ac284b3)

Fix #705

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific
- After: https://mrOutline--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific
