### PR TITLE
fix(ui): updated styles for tab panel image positioning[#709]

### DIFF
--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -249,7 +249,7 @@
         "text img"
         "buttons img"
         auto / 1fr 1fr;
-        min-block-size: 960px;
+        min-block-size: 50vh;
       }
 
       .buttons-wrapper {
@@ -274,12 +274,13 @@
     }
 
     .tab-content p:last-child picture {
+      align-items: center;
       block-size: 100%;
+      display: flex;
       inline-size: 100%;
     }
 
     .tab-content p:last-child picture img {
-      block-size: 100%;
       object-fit: cover;
       object-position: center;
     }
@@ -308,6 +309,10 @@
   .tabs .columns > div > div:first-child {
     inline-size: 100%;
     padding-inline-start: var(--space-16);
+  }
+
+  .tabs .tab-content p:last-child picture {
+    align-items: normal;
   }
 }
 


### PR DESCRIPTION


Fix #709 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://tabimage--esri-eds--esri.aem.live/en-us/about/about-esri/overview
