### PR TITLE
fix(ui): adjusted tab spacing[#723]

### DIFF
--- a/eds/blocks/tabs/tabs.css
+++ b/eds/blocks/tabs/tabs.css
@@ -226,14 +226,17 @@
       .tab-title {
         border-block-end: 3px solid transparent;
         display: block;
-        flex: 1;
+        inline-size: 100%;
         inset-block-start: 1px;
+        max-inline-size: 286px;
+        padding: .75rem;
         position: relative;
       }
 
       .tab-title button {
         inline-size: 100%;
-        padding: 1rem;
+        line-height: 1.25rem;
+        padding: 0;
       }
 
       .tab-title[aria-selected="false"]:hover, 


### PR DESCRIPTION
1. Adjusted spacing around the tab titles and also the alignment.
2. Spacing between tabs and content is adjusted via authoring.

Fix #723 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://tabsspacing--esri-eds--esri.aem.live/en-us/about/about-esri/americas
