### PR TITLE
fix(ui): mosaic reveal button spacing fix[#722]

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -13,6 +13,10 @@
   margin: 0 0 var(--space-4);
 }
 
+.section.mosaic-reveal-container > .default-content-wrapper .button-container {
+  padding-inline-start: 0;
+}
+
 .mosaic-reveal-container > div:first-child {
   box-sizing: border-box;
   padding: var(--space-8) 11%;


### PR DESCRIPTION

Fix #722 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://mosaicrevealbutton--esri-eds--esri.aem.live/en-us/about/about-esri/americas
