### PR TITLE
fix(ui): fix for images are smaller inside tabs when using media split[#727]

### DIFF
--- a/eds/blocks/columns/columns.css
+++ b/eds/blocks/columns/columns.css
@@ -33,6 +33,7 @@
 }
 
 .columns > div > .columns-img-col img {
+  aspect-ratio: 16 / 9;
   block-size: 100%;
   display: block;
   inline-size: 100%;


### PR DESCRIPTION
- Images rendered are smaller than the actual images.
- Downloaded the images from prod and reuploaded in the document and published.
- In addition to that, updating aspect ratio to 16/9 macthes the image size to prod.

Fix #727 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/technology
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/technology
- After: https://tabsimages--esri-eds--esri.aem.live/en-us/about/about-esri/technology
