### PR TITLE
fix(ccs): remove font-weight-normal from h2

### DIFF
--- a/eds/blocks/centered-content-switcher/centered-content-switcher.css
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.css
@@ -161,7 +161,6 @@
       & > h2 {
         color: var(--calcite-ui-text-1);
         font-size: var(--font-4);
-        font-weight: var(--calcite-font-weight-normal);
         line-height: 1.375;
         margin: 0 0 var(--space-4);
         margin-block-end: var(--space-2);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #736

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas#rio-de-janeiro-uses-gis-for-smart-city-initiative
- After: https://ccstitle--esri-eds--esri.aem.live/en-us/about/about-esri/americas#rio-de-janeiro-uses-gis-for-smart-city-initiative
