### PR TITLE
fix(ui): Added play pause controls to hero bg video[#717]

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -162,3 +162,82 @@
     inline-size: auto;
   }
 }
+
+.video-play-button {
+  align-items: center;
+  background-color: transparent;
+  block-size: 44px;
+  border: 0 solid var(--calcite-ui-text-1);
+  border-radius: 50%;
+  box-shadow: none;
+  cursor: pointer;
+  display: flex;
+  inline-size: 44px;
+  inset-block-start: var(--space-2);
+  inset-inline-end: var(--space-2);
+  justify-content: center;
+  margin: 0;
+  outline: 2px solid transparent;
+  padding: 0;
+  pointer-events: auto;
+  position: absolute;
+  transition: none;
+  z-index: 4;
+}
+
+.video-play-button:is(:hover, :focus) {
+  background: none;
+  box-shadow: none;
+}
+
+.play-progress-circle {
+  background-color: #f3f3f340;
+  block-size: 44px;
+  border-radius: 50%;
+  fill: transparent;
+  inline-size: 44px;
+  padding: 4px;
+  position: absolute;
+  stroke: var(--calcite-ui-text-1);
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+}
+
+.calcite-mode-dark .play-progress-circle {
+  background-color: #15151580;
+}
+
+.play-progress-circle .progress-circle {
+  stroke: var(--calcite-ui-text-1);
+  stroke-linecap: butt;
+  stroke-width: 5px;
+}
+
+.progress-background {
+  stroke: var(--calcite-ui-text-1);
+  stroke-width: 3px;
+}
+
+.video-play-button:focus {
+  border-radius: 50%;
+  box-shadow: none;
+  outline: 2px solid var(--calcite-ui-brand);
+}
+
+.video-play-button.paused::after {
+  inline-size: 10px;
+  margin-inline-start: 4px;
+  mask: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxMCAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDAuNTcxMjg5TDEwIDcuMDAxMjlMMCAxMy40MjkzVjAuNTcxMjg5WiIgZmlsbD0iIzE1MTUxNSIvPgo8L3N2Zz4K');
+}
+
+.video-play-button::after {
+  background-color: var(--calcite-ui-text-1);
+  background-size: 20px 20px;
+  block-size: 14px;
+  content: '';
+  display: inline-block;
+  inline-size: 12px;
+  mask: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxMiAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wIDBINVYxNEgwVjBaTTEyIDBIN1YxNEgxMlYwWiIgZmlsbD0iIzE1MTUxNSIvPgo8L3N2Zz4K');
+  mask-size: cover;
+  position: absolute;
+}

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -123,7 +123,6 @@ function setupVideoControl(playButtonElement, videoElement, videoLength) {
   videoElement.addEventListener('pause', () => { togglePlayButton(videoElement); });
 }
 
-
 /**
  * Binds a play button to a video element, setting up a video control to play
  * or pause the video when clicked.
@@ -146,7 +145,6 @@ function bindVideoElement(videoContainer) {
     }
   }
 }
-
 
 export default function decorate(block) {
   const newChildren = [...block.children]

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -1,6 +1,152 @@
 import { createAutoplayedVideo } from '../../scripts/scripts.js';
-import { calciteButton } from '../../scripts/dom-helpers.js';
+import { calciteButton, video, button } from '../../scripts/dom-helpers.js';
 import decorateModal from '../../scripts/delayed.js';
+
+/**
+ * Produce a calcite play button icon with appropriate attributes.
+ *
+ * @returns {HTMLButtonElement} A play/pause button
+ */
+function getVideoBtn() {
+  const videoButton = button({
+    class: 'video-play-button', 'aria-label': 'Play animation', tabindex: '0',
+  });
+
+  videoButton.innerHTML = `<svg class="play-progress-circle" viewBox="0 0 100 100">
+  <circle class="progress-background" r="45" cx="50" cy="50"></circle>
+  <circle class="progress-circle" r="41.25" cx="50" cy="50"></circle>
+</svg>`;
+  return videoButton;
+}
+
+/**
+ * Get all mp4 URLs from the block.
+ *
+ * @param {Element} block - The block element
+ *
+ * @returns {Array.<HTMLAnchorElement>} The array of mp4 urls
+ */
+function getVideoUrls(block) {
+  const aTags = block.querySelectorAll('a');
+  const mp4Urls = [];
+
+  aTags.forEach((aTag) => {
+    if (aTag.href.includes('.mp4')) {
+      mp4Urls.push(aTag);
+    }
+  });
+
+  return mp4Urls;
+}
+
+/**
+ * Play a video element with a promise, handling potential errors.
+ *
+ * @param {HTMLVideoElement} videoElement - The video element to play.
+ *
+ * @returns {Promise<void>}
+ */
+function playVideo(videoElement) {
+  const playPromise = videoElement.play();
+  if (playPromise !== undefined) {
+    playPromise.then(() => videoElement.play().then((r) => r).catch(() => null));
+  }
+}
+
+/**
+ * Sets up a video control with a play button, handling clicks and video element events.
+ *
+ * @param {HTMLElement} playButtonElement - The play button element.
+ * @param {HTMLVideoElement} videoElement - The video element to control.
+ *
+ * @returns {void}
+ */
+function setupVideoControl(playButtonElement, videoElement, videoLength) {
+  const totalFrames = 259.18;
+  const playProgressCircle = playButtonElement.querySelector('.play-progress-circle');
+  const progressCircle = playProgressCircle.querySelector('.progress-circle');
+  progressCircle.style.strokeDasharray = totalFrames;
+  progressCircle.style.strokeDashoffset = totalFrames;
+  const isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  function togglePlayButton(element) {
+    const videoContainer = element.closest('.block.hero');
+    const playButton = videoContainer.querySelector('.video-play-button');
+    if (element.paused) {
+      playButton.setAttribute('aria-label', 'pause animation');
+      playButton.classList.add('paused');
+    } else {
+      playButton.setAttribute('aria-label', 'play animation');
+      playButton.classList.remove('paused');
+    }
+  }
+
+  function updateDashOffset() {
+    const currentTime = (videoElement.currentTime / videoLength) * totalFrames;
+    progressCircle.style.strokeDashoffset = totalFrames - currentTime;
+
+    // Check if the video is a loop video
+    if (videoElement.closest('div.hero')?.classList.contains('loop-video')) {
+      if (currentTime >= totalFrames) {
+        videoElement.currentTime = 0; // Reset video to start
+        playVideo(videoElement); // Play the video again
+      }
+      requestAnimationFrame(updateDashOffset);
+    } else if (currentTime >= totalFrames) {
+      // Check if the video has ended, reset dash offset and play again
+      progressCircle.style.strokeDashoffset = totalFrames;
+    } else {
+      // Schedule the next update for smoother animation
+      requestAnimationFrame(updateDashOffset);
+    }
+    if (currentTime === totalFrames) {
+      progressCircle.style.strokeDashoffset = totalFrames;
+    }
+  }
+
+  if (!isReducedMotion.matches) {
+    playButtonElement.addEventListener('click', () => {
+      if (videoElement.paused) {
+        playVideo(videoElement);
+        togglePlayButton(videoElement);
+      } else {
+        videoElement.pause();
+        togglePlayButton(videoElement);
+      }
+      updateDashOffset();
+    });
+  }
+
+  videoElement.addEventListener('timeupdate', updateDashOffset);
+  videoElement.addEventListener('ended', () => { togglePlayButton(videoElement); });
+  videoElement.addEventListener('play', () => { togglePlayButton(videoElement); });
+  videoElement.addEventListener('pause', () => { togglePlayButton(videoElement); });
+}
+
+
+/**
+ * Binds a play button to a video element, setting up a video control to play
+ * or pause the video when clicked.
+ *
+ * @param {Element} videoContainer - A list of video container elements.
+ *
+ * @returns {void}
+ */
+function bindVideoElement(videoContainer) {
+  if (videoContainer) {
+    const videoElement = videoContainer.querySelector('video');
+    const playButton = videoContainer.querySelector('.video-play-button');
+
+    if (videoElement) {
+      videoElement.load();
+      videoElement.addEventListener('loadedmetadata', () => {
+        const videoLength = videoElement.duration;
+        setupVideoControl(playButton, videoElement, videoLength);
+      });
+    }
+  }
+}
+
 
 export default function decorate(block) {
   const newChildren = [...block.children]
@@ -67,6 +213,9 @@ export default function decorate(block) {
       block.append(foregroundDiv);
     } else {
       block.append(videoElement);
+      const videoBtn = getVideoBtn();
+      block.append(videoBtn);
+      bindVideoElement(block);
     }
   }
 


### PR DESCRIPTION
- Added play/pause controls for Hero block background video.
- Works as prod version.
- Added code for looping the video when needed.

Fix #717 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://herovideocontrols--esri-eds--esri.aem.live/en-us/about/about-esri/overview
