### PR TITLE
Large Content Stack Fix Top Padding

### DIFF
--- a/eds/blocks/large-content-stack/large-content-stack.css
+++ b/eds/blocks/large-content-stack/large-content-stack.css
@@ -32,7 +32,6 @@
     font-weight: var(--calcite-font-weight-normal);
     inline-size: 90%;
     margin: 0 auto;
-    padding-block-start: var(--space-10);
   }
 
   p {


### PR DESCRIPTION
Adjust top padding above h2 title to match PROD
https://www.esri.com/en-us/about/about-esri/company

Fix #726 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/company
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/company
- After: https://lcsH2--esri-eds--esri.aem.live/en-us/about/about-esri/company
