### PR TITLE
Load analytics attributes after the page loads[#755]

### DIFF
--- a/eds/scripts/delayed.js
+++ b/eds/scripts/delayed.js
@@ -61,7 +61,9 @@ window.dataLayer.push({
   },
 });
 
-loadAnalytics(window.dataLayer);
+window.addEventListener('load', () => {
+  loadAnalytics(window.dataLayer);
+});
 
 // decorate modal
 const toggleLoader = () => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #755 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://analyticsfix--esri-eds--esri.aem.live/en-us/about/about-esri/overview
