### PR TITLE
fix(ui): replace cta button with calcite button[#760]

### DIFF
--- a/eds/blocks/call-to-action/call-to-action.js
+++ b/eds/blocks/call-to-action/call-to-action.js
@@ -1,5 +1,5 @@
 import { loadFragment } from '../fragment/fragment.js';
-import { div } from '../../scripts/dom-helpers.js';
+import { div, calciteButton } from '../../scripts/dom-helpers.js';
 
 function decorateBlockSectionMode(block) {
   block.closest('.section')
@@ -22,4 +22,13 @@ export default async function decorate(block) {
     });
     block.replaceChildren(div(...fragment.children));
   }
+
+  block.querySelectorAll('.button-container a').forEach((anchorEl) => {
+    const appearance = anchorEl.classList.contains('secondary') ? 'outline' : 'solid';
+    anchorEl.parentElement.replaceWith(calciteButton({
+      appearance,
+      href: anchorEl.href,
+      label: anchorEl.textContent,
+    }, anchorEl.textContent));
+  });
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #760 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://ctabuttontocalcite--esri-eds--esri.aem.live/en-us/about/about-esri/overview
