### PR TITLE
fix(titles): ensure all are bold

### DIFF
--- a/eds/blocks/call-to-action/call-to-action.css
+++ b/eds/blocks/call-to-action/call-to-action.css
@@ -120,7 +120,6 @@
 
   h2 {
     font-size: var(--font-3);
-    font-weight: var(--calcite-font-weight-normal);
   }
 }
 

--- a/eds/blocks/location-presence/location-presence.css
+++ b/eds/blocks/location-presence/location-presence.css
@@ -25,7 +25,6 @@
 .location-presence-heading {
   color: var(--calcite-ui-text-1);
   font-size: var(--title-size);
-  font-weight: var(--calcite-font-weight-normal);
   margin-block: 3rem 0.5rem;
 }
 

--- a/eds/blocks/map/map.css
+++ b/eds/blocks/map/map.css
@@ -61,13 +61,6 @@
   display: none;
 }
 
-.map-default-content-wrapper > div > p {
-  font-size: var(--font-4);
-  font-weight: var(--calcite-font-weight-normal);
-  line-height: 1.375;
-  margin-block: 0 var(--space-4);
-}
-
 .map-frame {
   block-size: 100%;
   border: none;

--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -166,7 +166,6 @@
   box-sizing: border-box;
   color: var(--calcite-ui-text-1);
   font-size: 1.2rem;
-  font-weight: var(--calcite-font-weight-normal);
   inline-size: 100%;
   inset-block-end: 0;
   line-height: 1.375;


### PR DESCRIPTION
All titles should be bold; removing overrides.

Fix #766 
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://titles--esri-eds--esri.aem.live/en-us/about/about-esri/overview
