### PR TITLE
fix(storyteller): title, spacing, buttons

### DIFF
--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -53,8 +53,7 @@
   }
 
   h2 {
-    font-size: var(--font-4);
-    font-weight: var(--calcite-font-weight-bold);
+  margin-block-end: var(--space-1);
   }
 
   p {

--- a/eds/blocks/storyteller/storyteller.js
+++ b/eds/blocks/storyteller/storyteller.js
@@ -57,6 +57,7 @@ function decorateButtons(block) {
       href: anchorElement.getAttribute('href'),
       scale: anchorElement.getAttribute('scale') || 'l',
       appearance: index === 1 ? 'outline' : 'solid', // Set appearance to outline for the second anchor
+      kind: 'inverse'
     });
 
     linkButton.innerHTML = anchorElement.innerHTML;


### PR DESCRIPTION
- Adjust spacing
- set buttons to inverse
- fix title styles

Fix #767 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://<branch>--esri-eds--esri.aem.live/
