### PR TITLE
fix(mr): close up panel spacing

### DIFF
--- a/eds/blocks/mosaic-reveal/mosaic-reveal.css
+++ b/eds/blocks/mosaic-reveal/mosaic-reveal.css
@@ -134,7 +134,6 @@
 
 .mosaic-reveal .mosaic-reveal-content *:not(.category) {
   align-items: center;
-  block-size: 100%;
   opacity: 1;
   transform-origin: 50% 100%;
   transition: 0.5s ease;


### PR DESCRIPTION
Too much space between elements

Fix #771

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/locations
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/locations
- After: https://mrspacing--esri-eds--esri.aem.live/en-us/about/about-esri/locations
