### PR TITLE
fix(herobutton): fixed multiple issues related to hero button[#774]

### DIFF
--- a/eds/blocks/hero/hero.css
+++ b/eds/blocks/hero/hero.css
@@ -59,6 +59,7 @@
 
 .hero p.button-container a {
   margin-block: var(--space-2);
+  margin-inline: 0;
 }
 
 .hero video {
@@ -154,8 +155,14 @@
     max-inline-size: 720px;
   }
 
-  .hero :where(h1, p) {
+  .hero:not(.center) :where(h1, p) {
     inline-size: 90%;
+  }
+
+  .hero.center .content {
+    inline-size: 65%;
+    margin: auto;
+    max-inline-size: 600px;
   }
 
   .hero.small.center :is(.image, .content) {

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -194,7 +194,7 @@ export default function decorate(block) {
     }
   }
 
-  const videoAssets = [...block.querySelectorAll('a')].filter(a => !a.closest('.button-container'));
+  const videoAssets = [...block.querySelectorAll('a')].filter((a) => !a.closest('.button-container'));
   if (videoAssets.length > 0) {
     const videoAsset = videoAssets[videoAssets.length - 1];
 

--- a/eds/blocks/hero/hero.js
+++ b/eds/blocks/hero/hero.js
@@ -194,7 +194,7 @@ export default function decorate(block) {
     }
   }
 
-  const videoAssets = block.querySelectorAll('a');
+  const videoAssets = [...block.querySelectorAll('a')].filter(a => !a.closest('.button-container'));
   if (videoAssets.length > 0) {
     const videoAsset = videoAssets[videoAssets.length - 1];
 
@@ -217,6 +217,7 @@ export default function decorate(block) {
     }
   }
 
+  // add calcite button for video link
   const videoLink = block.querySelector('.video-link');
   if (videoLink) {
     const btnContainer = videoLink.closest('.button-container');
@@ -236,6 +237,20 @@ export default function decorate(block) {
         calciteBtn.setAttribute('tabindex', '0');
         decorateModal(videoLink.href, calciteBtn);
       });
+    }
+  }
+
+  const buttonContainer = block.querySelector('.content .button-container');
+  if (buttonContainer) {
+    const anchorEl = buttonContainer.querySelector('a');
+    if (anchorEl) {
+      const appearance = anchorEl.classList.contains('secondary') ? 'outline' : 'solid';
+      const calciteBtn = calciteButton({
+        appearance,
+        kind: 'inverse',
+        label: anchorEl.textContent.trim(),
+      }, anchorEl.textContent.trim());
+      buttonContainer.replaceWith(calciteBtn);
     }
   }
 }


### PR DESCRIPTION
- Play/Pause button now shows up only when there is a background video.
- Headline and button are centered.
- Buttons are converted to calcite.
- The discrepancy we're seeing with the background image is due to differences in how it's rendered: on production, the background image is applied via the style attribute using background-image, whereas on the EDS side, the image is rendered as DM image.

Fix #774 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/americas
- After: https://herobutton--esri-eds--esri.aem.live/en-us/about/about-esri/americas
