### PR TITLE
Centered content switcher - Styles update[775]

### DIFF
--- a/eds/blocks/centered-content-switcher/centered-content-switcher.css
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.css
@@ -143,15 +143,53 @@
       text-align: center;
 
       & > p {
-        color: var(--calcite-ui-text-2);
-        font-size: var(--font-minus-2);
+        color: var(--calcite-ui-text-1);
+        font-size: var(--font-0);
+        inline-size: 680px;
+        margin: 0 auto var(--space-8);
+        max-inline-size: 90%;
+      }
+
+      & > p span.icon {
+        block-size: 64px;
+        inline-size: 64px;
+        max-inline-size: none;
+      }
+
+      & > p span.icon img {
+        filter: var(--theme-color);
+      }
+
+      & > p:has(span.icon) {
+        margin: 0 auto var(--space-5);
+      }
+
+      & > p:has(span.icon) + p {
+        font-size: var(--font-1);
+        margin-block-end: var(--space-4);
+      }
+
+      & > p:nth-of-type(4) {
         font-weight: var(--calcite-font-weight-bold);
-        margin-block: 0 var(--space-2);
-        padding-block-start: var(--space-5);
+        margin-block-end: .1rem;
+      }
+
+      & > p:nth-of-type(5) {
+        color: var(--calcite-ui-text-2);
+        font-size: var(--font-minus-1);
+        margin-block-end: var(--space-4);
       }
 
       & > p:first-child {
+        color: var(--calcite-ui-text-3);
+        font-size: var(--font-minus-1);
+        font-weight: var(--calcite-font-weight-bold);
+        margin-block-end: var(--space-1);
         text-transform: uppercase;
+      }
+
+      & > p.button-container{
+        margin-block-end: 0
       }
 
       calcite-button {

--- a/eds/blocks/centered-content-switcher/centered-content-switcher.js
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.js
@@ -12,7 +12,7 @@ export default function decorate(block) {
   block.classList.add('calcite-mode-dark');
   document.querySelector('.centered-content-switcher-container').classList.add('calcite-mode-dark');
 
-  block.querySelectorAll('img').forEach((image) => image
+  block.querySelectorAll('picture img').forEach((image) => image
     .closest('picture')
     .replaceWith(
       createOptimizedPicture(image.src, image.alt, false, [{ width: '2560' }]),
@@ -164,5 +164,10 @@ export default function decorate(block) {
     }
   });
 
+  block.querySelectorAll('p').forEach((p) => {
+    if (!p.textContent.trim() && !p.children.length) {
+      p.remove();
+    }
+  });
   changeSelectedTab(selectedIdx);
 }

--- a/eds/blocks/centered-content-switcher/centered-content-switcher.js
+++ b/eds/blocks/centered-content-switcher/centered-content-switcher.js
@@ -164,9 +164,9 @@ export default function decorate(block) {
     }
   });
 
-  block.querySelectorAll('p').forEach((p) => {
-    if (!p.textContent.trim() && !p.children.length) {
-      p.remove();
+  block.querySelectorAll('p').forEach((paragraph) => {
+    if (!paragraph.textContent.trim() && !paragraph.children.length) {
+      paragraph.remove();
     }
   });
   changeSelectedTab(selectedIdx);


### PR DESCRIPTION
- Updated styles for content in CCS.
- Added quote style 
- Re-authored the background images for all slides.
- EDS live url might look broken because of the quote addition. It will be fixed once the code is merged.

Fix #775 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/asia-pacific
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific
- After: https://ccsstyles--esri-eds--esri.aem.live/en-us/about/about-esri/asia-pacific?query
