### PR TITLE
Request images at /eds/... instead to bypass cdn issues

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,7 @@ export default [
   {
     ignores: [
       'eds/scripts/aem.js',
-      'helix-importer-ui',
+      'tools/importer/helix-importer-ui',
       'tools/importer/import.bundle.js',
     ],
   },


### PR DESCRIPTION
An interesting feature of the media bus is that it is "flat", meaning that the "media" files can be found at any level, so this way the CDN can serve them.

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://image-cdn-fix--esri-eds--esri.aem.live/
