### PR TITLE
fix(st): fix for storyteller overlay[#782]

### DIFF
--- a/eds/blocks/storyteller/storyteller.css
+++ b/eds/blocks/storyteller/storyteller.css
@@ -144,8 +144,11 @@
 
   .overlay {
     background-color: var(--esri-ui-opacity85-inverse);
+    block-size: fit-content;
     color: var(--calcite-ui-text-1);
+    display: inline-block;
     inset-block-end: 0;
+    inset-block-start: unset;
     inset-inline-start: 0;
     padding: var(--space-6);
     position: absolute;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #782 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/en-us/about/about-esri/overview
- After: https://stoverlay--esri-eds--esri.aem.live/en-us/about/about-esri/overview
