### PR TITLE
feat(yaml): change mountpoint to da

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,7 @@
 mountpoints:
-  /: https://esriis.sharepoint.com/:f:/r/sites/EsriMarketingPublic/Shared%20Documents/sites/esri?csf=1&web=1&e=Of2kRV
+  /:
+    url: https://content.da.live/esri/esri-eds/
+    type: markup
+
+#mountpoints:
+ # /: https://esriis.sharepoint.com/:f:/r/sites/EsriMarketingPublic/Shared%20Documents/sites/esri?csf=1&web=1&e=Of2kRV


### PR DESCRIPTION

This pull request updates the mountpoint configuration in `fstab.yaml` to use a new content source and explicitly sets its type. The previous SharePoint-based mountpoint is replaced with a new URL and configuration.

Configuration changes:

* Changed the `/` mountpoint to use `https://content.da.live/esri/esri-eds/` as the new URL and set its type to `markup` for clearer content handling.
* Commented out the previous SharePoint mountpoint configuration for reference and potential rollback.

Fix #784 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri-eds--esri.aem.live/
- After: https://mountpoint--esri-eds--esri.aem.live/
